### PR TITLE
Tests are failing on *nix test machines

### DIFF
--- a/src/InsertionsClient/Api/DefaultConfigUpdater.cs
+++ b/src/InsertionsClient/Api/DefaultConfigUpdater.cs
@@ -120,6 +120,9 @@ namespace Microsoft.Net.Insertions.Api
                     if(!File.Exists(configFileAbsolutePath))
                     {
                         Trace.WriteLine($"File for the .packageconfig listed under {InsertionConstants.DefaultConfigFile} was not found on disk. Path: {configFileAbsolutePath}");
+
+                        string separatorFixedPath = configFileAbsolutePath.Replace( '\\', '/');
+                        Trace.WriteLine($"Alternative file path: {separatorFixedPath} exists: {File.Exists(separatorFixedPath)}");
                         continue;
                     }
 

--- a/src/InsertionsClient/Api/DefaultConfigUpdater.cs
+++ b/src/InsertionsClient/Api/DefaultConfigUpdater.cs
@@ -115,14 +115,11 @@ namespace Microsoft.Net.Insertions.Api
                         continue;
                     }
 
-                    string configFileAbsolutePath = Path.Combine(configsDirectory, configFileRelativePath);
-
+                    string configFileAbsolutePath = Path.Combine(configsDirectory, configFileRelativePath).Replace('\\', '/');
+                    
                     if(!File.Exists(configFileAbsolutePath))
                     {
                         Trace.WriteLine($"File for the .packageconfig listed under {InsertionConstants.DefaultConfigFile} was not found on disk. Path: {configFileAbsolutePath}");
-
-                        string separatorFixedPath = configFileAbsolutePath.Replace( '\\', '/');
-                        Trace.WriteLine($"Alternative file path: {separatorFixedPath} exists: {File.Exists(separatorFixedPath)}");
                         continue;
                     }
 

--- a/tests/InsertionsClientTest/InsertionsClientTest.csproj
+++ b/tests/InsertionsClientTest/InsertionsClientTest.csproj
@@ -108,6 +108,9 @@
     <None Update="Assets\DotNetCoreSDK\Toolset.packageconfig">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Assets\ignored.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Assets\manifest.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -136,6 +139,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="Assets\Microsoft.VisualStudio.MinShell\vs-validation.packageconfig">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Assets\TargetingPacks.packageconfig">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="Assets\VS-Platform\VS-Platform.packageconfig">


### PR DESCRIPTION
Relative paths to .packageconfig files specified in default.config file contain backslash characters. This is causing `file not found` errors during some of the tests.

This fix replaces backslash characters with forward-slash characters before attempting to access .packageconfig files.