### PR TITLE
Update to handle .NET DEV UX team default ignored assemblies case.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@
     > _-m:c:\files\manifest.json_
 1. **-i:** Path to ignored packages file [**optional**]. Example: 
     > _-i:c:\files\ignore.txt_
+1. **-idut** Indicates that packages relevant to the .NET Dev UX team are ignored [**optional**].  If **-i:** is also set, the file specified with that option is used, superceding **-idut**.
 1. **-w:** Maximum allowed duration in seconds [**optional**].  Example: 
     > _-w:60_
 1. **-c:** Maximum concurrency of default.config version updates [**optional**].  Example:
@@ -50,14 +51,25 @@ Each log line details...
 1. Navigate to the location of _InsertionsClient.exe_
 1. Alternative, if on WINDOWS, set **InsertionsClient** on the %path% variable to run the application from any location
 1. Launch _InsertionsClient.exe_ with the proper parameters
-### Example
-The example below details starting the application for the following conditions...
+### Examples
+The examples below rely on the following conditions...
 1. _InsertionsClient.exe_ located on \tools
 1. _default.config_ located in \repos\Assets
 1. _manifest.json_ located in \repos\Assets
+
+#### Opting to Specify File with NuGet Packages to Ignore
+Location of additional needed resources...
 1. _ignored.txt_ located in \repos\Assets
 <pre>
 $ \tools\InsertionsClient.exe -d:\repos\Assets\default.config -m:\repos\Assets\manifest.json -i:\repos\Assets\ignored.txt
+</pre>
+#### Opting to Ignore .NET Dev UX NuGet Packages
+<pre>
+$ \tools\InsertionsClient.exe -d:\repos\Assets\default.config -m:\repos\Assets\manifest.json -idut
+</pre>
+#### Opting Not to Ignore any NuGet Packages
+<pre>
+$ \tools\InsertionsClient.exe -d:\repos\Assets\default.config -m:\repos\Assets\manifest.json
 </pre>
 
 ## Output

--- a/src/InsertionsClient/Api/DefaultConfigUpdater.cs
+++ b/src/InsertionsClient/Api/DefaultConfigUpdater.cs
@@ -9,7 +9,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Xml;
 using System.Xml.Linq;
-using System.Threading.Tasks;
 using System.Linq;
 using System.Text;
 

--- a/src/InsertionsClient/Api/IInsertionApi.cs
+++ b/src/InsertionsClient/Api/IInsertionApi.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using Microsoft.Net.Insertions.Models;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
 [assembly:InternalsVisibleTo("InsertionsClientTest")]
@@ -14,11 +15,28 @@ namespace Microsoft.Net.Insertions.Api
         /// <summary>
         /// Updates default.config NuGet package versions from matching manifest.json assets.
         /// </summary>
-        /// <param name="manifestFile">Specified manifest.json</param>
-        /// <param name="defaultConfigFile">Full path to &quot;default.config&quot; file</param>
+        /// <param name="manifestFile">Specified manifest.json.</param>
+        /// <param name="defaultConfigFile">Full path to &quot;default.config&quot; file.</param>
+        /// <returns><see cref="UpdateResults"/> detailing the operation's outcome.</returns>
+        UpdateResults UpdateVersions(string manifestFile, string defaultConfigFile);
+
+        /// <summary>
+        /// Updates default.config NuGet package versions from matching manifest.json assets.
+        /// </summary>
+        /// <param name="manifestFile">Specified manifest.json.</param>
+        /// <param name="defaultConfigFile">Full path to &quot;default.config&quot; file.</param>
         /// <param name="ignoredPackagesFile">Full path to the file which lists all the packages to ignore line by line.
         /// Package ids should be given identical to how they are written in &quot;default.config&quot;.</param>
         /// <returns><see cref="UpdateResults"/> detailing the operation's outcome.</returns>
         UpdateResults UpdateVersions(string manifestFile, string defaultConfigFile, string ignoredPackagesFile);
+
+        /// <summary>
+        /// Updates default.config NuGet package versions from matching manifest.json assets.
+        /// </summary>
+        /// <param name="manifestFile">Specified manifest.json.</param>
+        /// <param name="defaultConfigFile">Full path to &quot;default.config&quot; file.</param>
+        /// <param name="packagesToIgnore"><see cref="HashSet{string}"/> of packages to ignore.</param>
+        /// <returns><see cref="UpdateResults"/> detailing the operation's outcome.</returns>
+        UpdateResults UpdateVersions(string manifestFile, string defaultConfigFile, HashSet<string> packagesToIgnore);
     }
 }

--- a/src/InsertionsClient/Api/Providers/InsertionApi.cs
+++ b/src/InsertionsClient/Api/Providers/InsertionApi.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Net.Insertions.Api.Providers
 
             UpdateResults results = new UpdateResults
             {
-                IgnoreNuGets = packagesToIgnore
+                IgnoredNuGets = packagesToIgnore
             };
             Stopwatch overallRunStopWatch = Stopwatch.StartNew();
             using CancellationTokenSource source = new CancellationTokenSource(TimeSpan.FromSeconds(_maxWaitSeconds));

--- a/src/InsertionsClient/Common/Constants/InsertionConstants.cs
+++ b/src/InsertionsClient/Common/Constants/InsertionConstants.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Collections.Generic;
+
 namespace Microsoft.Net.Insertions.Common.Constants
 {
     internal static class InsertionConstants
@@ -7,5 +9,14 @@ namespace Microsoft.Net.Insertions.Common.Constants
         internal const string DefaultConfigFile = "default.config";
 
         internal const string ManifestFile = "manifest.json";
+
+        internal static readonly HashSet<string> DefaultDevUxTeamPackages = new HashSet<string>
+        {
+            "Microsoft.VisualStudio.LiveShare",
+            "System.Reflection.Metadata",
+            "VS.ExternalAPIs.MSBuild",
+            "VS.Tools.Net.Core.SDK.Resolver",
+            "VS.Tools.Net.Core.SDK.x86"
+        };
     }
 }

--- a/src/InsertionsClient/ConsoleApp/Program.cs
+++ b/src/InsertionsClient/ConsoleApp/Program.cs
@@ -22,6 +22,8 @@ namespace Microsoft.Net.Insertions.ConsoleApp
 
         private const string SwitchIgnorePackages = "-i:";
 
+        private const string SwitchIgnoreDevUxTeamPackages = "-idut";
+
         private const string SwitchMaxWaitSeconds = "-w:";
 
         private const string SwitchMaxConcurrency = "-c:";
@@ -50,6 +52,8 @@ namespace Microsoft.Net.Insertions.ConsoleApp
         private static string ManifestFile = string.Empty;
 
         private static string IgnoredPackagesFile = string.Empty;
+
+        private static bool IgnoreDevUxTeamPackagesCase;
 
         private static int MaxWaitSeconds = 75;
 
@@ -86,8 +90,21 @@ namespace Microsoft.Net.Insertions.ConsoleApp
 
             IInsertionApiFactory apiFactory = new InsertionApiFactory();
             IInsertionApi api = apiFactory.Create(MaxWaitSeconds, MaxConcurrency);
-            UpdateResults results = api.UpdateVersions(ManifestFile, DefaultConfigFile, IgnoredPackagesFile);
-            
+
+            UpdateResults results;
+            if (!string.IsNullOrWhiteSpace(IgnoredPackagesFile))
+            {
+                results = api.UpdateVersions(ManifestFile, DefaultConfigFile, IgnoredPackagesFile);
+            }
+            else if (IgnoreDevUxTeamPackagesCase)
+            {
+                results = api.UpdateVersions(ManifestFile, DefaultConfigFile, InsertionConstants.DefaultDevUxTeamPackages);
+            }
+            else
+            {
+                results = api.UpdateVersions(ManifestFile, DefaultConfigFile);
+            }
+
             ShowResults(results);
 
             Trace.WriteLine($"Log: {LogFile}{Environment.NewLine}");
@@ -180,6 +197,10 @@ namespace Microsoft.Net.Insertions.ConsoleApp
                 else if (arg.StartsWith(SwitchMaxConcurrency))
                 {
                     ProcessArgumentInt(arg, SwitchMaxConcurrency, $"Specified \"max concurrency\":", ref MaxConcurrency);
+                }
+                else if (arg.StartsWith(SwitchIgnoreDevUxTeamPackages))
+                {
+                    IgnoreDevUxTeamPackagesCase = true;
                 }
             }
 

--- a/src/InsertionsClient/ConsoleApp/Program.cs
+++ b/src/InsertionsClient/ConsoleApp/Program.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Net.Insertions.ConsoleApp
 
         private static string IgnoredPackagesFile = string.Empty;
 
-        private static bool IgnoreDevUxTeamPackagesCase;
+        private static bool IgnoreDevUxTeamPackagesScenario;
 
         private static int MaxWaitSeconds = 75;
 
@@ -96,7 +96,7 @@ namespace Microsoft.Net.Insertions.ConsoleApp
             {
                 results = api.UpdateVersions(ManifestFile, DefaultConfigFile, IgnoredPackagesFile);
             }
-            else if (IgnoreDevUxTeamPackagesCase)
+            else if (IgnoreDevUxTeamPackagesScenario)
             {
                 results = api.UpdateVersions(ManifestFile, DefaultConfigFile, InsertionConstants.DefaultDevUxTeamPackages);
             }
@@ -200,7 +200,7 @@ namespace Microsoft.Net.Insertions.ConsoleApp
                 }
                 else if (arg.StartsWith(SwitchIgnoreDevUxTeamPackages))
                 {
-                    IgnoreDevUxTeamPackagesCase = true;
+                    IgnoreDevUxTeamPackagesScenario = true;
                 }
             }
 

--- a/src/InsertionsClient/Models/UpdateResults.cs
+++ b/src/InsertionsClient/Models/UpdateResults.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Net.Insertions.Models
         /// </summary>
         public IEnumerable<string> UpdatedNuGets => _updatedNugetsList;
 
-        public HashSet<string> IgnoreNuGets { get; set; }
+        public HashSet<string> IgnoredNuGets { get; set; }
 
         /// <summary>
         /// Duration in ms of <see cref="IInsertionApi.UpdateVersions(string, string, string)"/> attempt.

--- a/src/InsertionsClient/Models/UpdateResults.cs
+++ b/src/InsertionsClient/Models/UpdateResults.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Net.Insertions.Models
         /// </summary>
         public IEnumerable<string> UpdatedNuGets => _updatedNugetsList;
 
+        public HashSet<string> IgnoreNuGets { get; set; }
+
         /// <summary>
         /// Duration in ms of <see cref="IInsertionApi.UpdateVersions(string, string, string)"/> attempt.
         /// </summary>

--- a/src/InsertionsClient/Properties/launchSettings.json
+++ b/src/InsertionsClient/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "InsertionsClient": {
       "commandName": "Project",
-      "commandLineArgs": "-d:C:\\temp\\insertions\\default.config -m:C:\\temp\\insertions\\manifest.json"
+      "commandLineArgs": "-d:C:\\temp\\insertions\\default.config -m:C:\\temp\\insertions\\manifest.json -i:C:\\temp\\insertions\\ignored.txt"
     }
   }
 }

--- a/tests/InsertionsClientTest/IgnoreCase.cs
+++ b/tests/InsertionsClientTest/IgnoreCase.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace InsertionsClientTest
+{
+    public enum IgnoreCase
+    {
+        DefaultDevUxTeamPackages,
+        SpecifiedFile,
+        None
+    }
+}

--- a/tests/InsertionsClientTest/InsertionApiTest.cs
+++ b/tests/InsertionsClientTest/InsertionApiTest.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Net.Insertions.Api;
+using Microsoft.Net.Insertions.Api.Providers;
+using Microsoft.Net.Insertions.Common.Constants;
+using Microsoft.Net.Insertions.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace InsertionsClientTest
+{
+    [TestClass]
+    public class InsertionApiTest
+    {
+		[TestMethod]
+        [DataRow(IgnoreCase.None)]
+        [DataRow(IgnoreCase.DefaultDevUxTeamPackages)]
+        [DataRow(IgnoreCase.SpecifiedFile)]
+        public void TestLoadFile(IgnoreCase ignoreCase)
+		{
+            IInsertionApiFactory apiFactory = new InsertionApiFactory();
+            IInsertionApi api = apiFactory.Create(75, 4);
+
+            UpdateResults results;
+            string assetsDirectory = Path.Combine(Directory.GetCurrentDirectory(), "Assets");
+            string manifestFile = Path.Combine(assetsDirectory, "manifest.json");
+            string defaultConfigFile = Path.Combine(assetsDirectory, "default.config");
+
+            results = ignoreCase switch
+            {
+                IgnoreCase.DefaultDevUxTeamPackages => api.UpdateVersions(manifestFile, defaultConfigFile, InsertionConstants.DefaultDevUxTeamPackages),
+                IgnoreCase.SpecifiedFile => api.UpdateVersions(manifestFile, defaultConfigFile, Path.Combine(assetsDirectory, "ignored.txt")),
+                _ => api.UpdateVersions(manifestFile, defaultConfigFile),
+            };
+
+            Assert.IsTrue(ListsAreEquivalent(ignoreCase, results?.IgnoreNuGets), $"Mismatched ignore packages for {ignoreCase}");
+        }
+
+        private bool ListsAreEquivalent(IgnoreCase ignoreCase, HashSet<string> results)
+        {
+            HashSet<string> expected = ignoreCase switch
+            {
+                IgnoreCase.DefaultDevUxTeamPackages => InsertionConstants.DefaultDevUxTeamPackages,
+                IgnoreCase.SpecifiedFile =>
+                new HashSet<string>(File.ReadAllLines(Path.Combine(Directory.GetCurrentDirectory(), "Assets", "ignored.txt"))),
+                _ => null,
+            };
+
+            if (expected == null)
+            {
+                return results == null;
+            }
+
+            return results == null ? false : !expected.Except(results).Any();
+        }
+    }
+}

--- a/tests/InsertionsClientTest/InsertionApiTest.cs
+++ b/tests/InsertionsClientTest/InsertionApiTest.cs
@@ -14,12 +14,12 @@ namespace InsertionsClientTest
     [TestClass]
     public class InsertionApiTest
     {
-		[TestMethod]
+        [TestMethod]
         [DataRow(IgnoreCase.None)]
         [DataRow(IgnoreCase.DefaultDevUxTeamPackages)]
         [DataRow(IgnoreCase.SpecifiedFile)]
         public void TestLoadFile(IgnoreCase ignoreCase)
-		{
+        {
             IInsertionApiFactory apiFactory = new InsertionApiFactory();
             IInsertionApi api = apiFactory.Create(75, 4);
 
@@ -35,7 +35,7 @@ namespace InsertionsClientTest
                 _ => api.UpdateVersions(manifestFile, defaultConfigFile),
             };
 
-            Assert.IsTrue(ListsAreEquivalent(ignoreCase, results?.IgnoreNuGets), $"Mismatched ignore packages for {ignoreCase}");
+            Assert.IsTrue(ListsAreEquivalent(ignoreCase, results?.IgnoredNuGets), $"Mismatched ignore packages for {ignoreCase}");
         }
 
         private bool ListsAreEquivalent(IgnoreCase ignoreCase, HashSet<string> results)


### PR DESCRIPTION
Delivers on #10 

- added option to ignore default .NET DEV UX team packages
- updated the API accordingly
- new unit tests to nominatively verify ignore assemblies cases
- updated ReadMe with new switch