### PR TITLE
Add support for updating .props files

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -67,25 +67,25 @@ The examples below rely on the following conditions...
 #### Opting to Specify File with NuGet Packages to Ignore
 Location of additional needed resources...
 1. _ignored.txt_ located in \repos\Assets
-<pre>
+```pwsh
 $ \tools\InsertionsClient.exe -d:\repos\Assets\default.config -m:\repos\Assets\manifest.json -i:\repos\Assets\ignored.txt
-</pre>
+```
 #### Opting to Ignore .NET Dev UX NuGet Packages
-<pre>
+```pwsh
 $ \tools\InsertionsClient.exe -d:\repos\Assets\default.config -m:\repos\Assets\manifest.json -idut
-</pre>
+```
 #### Opting Not to Ignore any NuGet Packages
-<pre>
+```pwsh
 $ \tools\InsertionsClient.exe -d:\repos\Assets\default.config -m:\repos\Assets\manifest.json
-</pre>
+```
 #### Specifying an Access Token to Update .props Files
-<pre>
+```pwsh
 $ \tools\InsertionsClient.exe -d:\repos\Assets\default.config -m:\repos\Assets\manifest.json -a:vv8ofhtojf7xuhehroaq9k5zvvxstrqg2dzsedhlu757
-</pre>
+```
 #### Specifying a .props File Search Directory
-<pre>
+```pwsh
 $ \tools\InsertionsClient.exe -d:\repos\Assets\default.config -m:\repos\Assets\manifest.json -a:vv8ofhtojf7xuhehrFxq9k5zvvxstrqg2dzsedhlu757 -p:C:\VS\src\SetupPackages\DotNetCoreSDK
-</pre>
+```
 
 ## Output
 _InsertionsClient.exe_ outputs the results of running operations to both a persistent log file and to console.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,12 +1,13 @@
 # Overview
-**InsertionsClient** updates the versions of NuGet packages in _default.config_ with the corresponding versions specified in _manifest.json_ assets.
+**InsertionsClient** updates the versions of NuGet packages in _default.config_ with the corresponding versions specified in _manifest.json_ assets. It also updates the values of properties defined in .props files.
 
 ## How does **InsertionsClient** work?
 1. Loads into memory the contents of both _default.config_ and _manifest.json_ as well as all the _.packageconfig_ files listed in the _default.config_
 1. Searches _default.config_ and _.packageconfig_ files for corresponding NuGet packages for each _manifest.json_ asset
 1. For every match, the NuGet version in the config file is updated with that of the corresponding _manifest.json_ asset
 1. The updated _default.config_ and _.packageconfig_'s are saved on disk
-
+1. If an access token is specified with **-a:** switch, binaries for the updated packages are downloaded. Content of the packages are used to update the values of properties defined in `PackagePreprocessorDefinitions` tag in .props files
+1. Modified .props file are saved on disk
 ## Input
 1. **-d:** Path to the default.config.  Example: 
     > _-d:c:\default.config_
@@ -15,6 +16,11 @@
 1. **-i:** Path to ignored packages file [**optional**]. Example: 
     > _-i:c:\files\ignore.txt_
 1. **-idut** Indicates that packages relevant to the .NET Dev UX team are ignored [**optional**].  If **-i:** is also set, the file specified with that option is used, superceding **-idut**.
+    > _-idut_
+1. **-p**: Path to the directory to search for .props files [**optional**]. If left unspecified, all the .props files under src\SetupPackages in local VS repo will be searched.
+    > _-p:C:\VS\src\SetupPackages_
+1. **-a**: Personal access token to access packages in [VS feed](https://pkgs.dev.azure.com/devdiv/_packaging/VS-CoreXtFeeds/nuget/v3/index.json) [**optional**]. If not specified, props files will not be updated.
+    > _-a:vv8ofhtojf7xuhehrFxq9k5zvvxstrqg2dzsedhlu757_
 1. **-w:** Maximum allowed duration in seconds [**optional**].  Example: 
     > _-w:60_
 1. **-c:** Maximum concurrency of default.config version updates [**optional**].  Example:
@@ -22,6 +28,7 @@
 
 _Warnings_
 1. NO SPACES ALLOWED IN EITHER default.config OR manifest.json FILE PATHS
+1. NO SPACES ALLOWED IN props file search directory
 1. The default duration & concurrency values should suffice
 
 ## Log
@@ -70,6 +77,14 @@ $ \tools\InsertionsClient.exe -d:\repos\Assets\default.config -m:\repos\Assets\m
 #### Opting Not to Ignore any NuGet Packages
 <pre>
 $ \tools\InsertionsClient.exe -d:\repos\Assets\default.config -m:\repos\Assets\manifest.json
+</pre>
+#### Specifying an Access Token to Update .props Files
+<pre>
+$ \tools\InsertionsClient.exe -d:\repos\Assets\default.config -m:\repos\Assets\manifest.json -a:vv8ofhtojf7xuhehroaq9k5zvvxstrqg2dzsedhlu757
+</pre>
+#### Specifying a .props File Search Directory
+<pre>
+$ \tools\InsertionsClient.exe -d:\repos\Assets\default.config -m:\repos\Assets\manifest.json -a:vv8ofhtojf7xuhehrFxq9k5zvvxstrqg2dzsedhlu757 -p:C:\VS\src\SetupPackages\DotNetCoreSDK
 </pre>
 
 ## Output

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,8 +21,10 @@
     > _-p:C:\VS\src\SetupPackages_
 1. **-a**: Personal access token to access packages in [VS feed](https://pkgs.dev.azure.com/devdiv/_packaging/VS-CoreXtFeeds/nuget/v3/index.json) [**optional**]. If not specified, props files will not be updated.
     > _-a:vv8ofhtojf7xuhehrFxq9k5zvvxstrqg2dzsedhlu757_
-1. **-w:** Maximum allowed duration in seconds [**optional**].  Example: 
+1. **-w:** Maximum allowed duration in seconds, excluding downloads [**optional**].  Example: 
     > _-w:60_
+1. **-ds:** Maximum allowed duration in seconds that can be spent downloading nuget packages [**optional**].  Example: 
+    > _-ds:240_
 1. **-c:** Maximum concurrency of default.config version updates [**optional**].  Example:
     > _-c:10_
 

--- a/src/InsertionsClient/Api/DefaultConfigUpdater.cs
+++ b/src/InsertionsClient/Api/DefaultConfigUpdater.cs
@@ -91,6 +91,7 @@ namespace Microsoft.Net.Insertions.Api
             }
             catch(Exception e)
             {
+                error = e.Message;
                 Trace.WriteLine($"Loading of {InsertionConstants.DefaultConfigFile} content has failed with exception:{Environment.NewLine} {e.ToString()}");
                 return false;
             }

--- a/src/InsertionsClient/Api/DefaultConfigUpdater.cs
+++ b/src/InsertionsClient/Api/DefaultConfigUpdater.cs
@@ -14,10 +14,10 @@ using System.Text;
 
 namespace Microsoft.Net.Insertions.Api
 {
-    /// <summary>
-    /// Manages loading and updating &quot;default.config&quot; file and &quot;.packageconfig&quot; files listed in it.
-    /// </summary>
-    internal sealed class DefaultConfigUpdater
+	/// <summary>
+	/// Manages loading and updating &quot;default.config&quot; file and &quot;.packageconfig&quot; files listed in it.
+	/// </summary>
+	internal sealed class DefaultConfigUpdater
     {
         private const string ElementNamePackage = "package";
 
@@ -170,6 +170,33 @@ namespace Microsoft.Net.Insertions.Api
             // Store the document. Store a junk value (0) with it, because we have to.
             _modifiedDocuments[xElement.Document] = 0;
             return true;
+        }
+
+        /// <summary>
+        /// Returns the link attribute defined in the xml attributes of the package.
+        /// </summary>
+        /// <param name="packageId">Id of the package, link of which will be returned.</param>
+        /// <returns>Returns the value of the link attribute. 
+        /// Returns null, if attribute or package is not found.</returns>
+        /// <remarks>This method is safe to call simultaneously from multiple threads.</remarks>
+        public string? GetPackageLink(string packageId)
+        {
+            if(!_packageXElements.TryGetValue(packageId, out XElement? xElement))
+            {
+                // Package was not found.
+                Trace.WriteLine($"Package {packageId} was not found in default.config/.packageconfig files.");
+                return null;
+            }
+
+            XAttribute linkAttribute = xElement.Attribute("link");
+            if (linkAttribute == null)
+            {
+                // Attribute was not found
+                Trace.WriteLine($"Package {packageId} does not have a link attribute in {_documentPaths[xElement.Document]}:{((IXmlLineInfo)xElement).LineNumber}");
+                return null;
+            }
+
+            return linkAttribute.Value;
         }
 
         /// <summary>

--- a/src/InsertionsClient/Api/DefaultConfigUpdater.cs
+++ b/src/InsertionsClient/Api/DefaultConfigUpdater.cs
@@ -3,21 +3,21 @@
 using Microsoft.Net.Insertions.Common.Constants;
 using Microsoft.Net.Insertions.Models;
 using System;
-using System.Collections.Generic;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Xml;
-using System.Xml.Linq;
 using System.Linq;
 using System.Text;
+using System.Xml;
+using System.Xml.Linq;
 
 namespace Microsoft.Net.Insertions.Api
 {
-	/// <summary>
-	/// Manages loading and updating &quot;default.config&quot; file and &quot;.packageconfig&quot; files listed in it.
-	/// </summary>
-	internal sealed class DefaultConfigUpdater
+    /// <summary>
+    /// Manages loading and updating &quot;default.config&quot; file and &quot;.packageconfig&quot; files listed in it.
+    /// </summary>
+    internal sealed class DefaultConfigUpdater
     {
         private const string ElementNamePackage = "package";
 
@@ -89,7 +89,7 @@ namespace Microsoft.Net.Insertions.Api
                 defaultConfigXml = XDocument.Load(defaultConfigPath, LoadOptions.SetLineInfo | LoadOptions.PreserveWhitespace);
                 Trace.WriteLine($"Loaded {InsertionConstants.DefaultConfigFile} content.");
             }
-            catch(Exception e)
+            catch (Exception e)
             {
                 error = e.Message;
                 Trace.WriteLine($"Loading of {InsertionConstants.DefaultConfigFile} content has failed with exception:{Environment.NewLine} {e.ToString()}");
@@ -101,23 +101,23 @@ namespace Microsoft.Net.Insertions.Api
 
             // Find xml elements that define additional .packageconfig in them.
             IEnumerable<XElement> additionalConfigParents = defaultConfigXml.Descendants(ElementNameAdditionalConfigsParent);
-            if(additionalConfigParents != null)
+            if (additionalConfigParents != null)
             {
                 string configsDirectory = Path.GetDirectoryName(defaultConfigPath) ?? string.Empty;
 
-                foreach(XElement packageconfigXElement in additionalConfigParents.SelectMany(p => p.Elements(ElementNameAdditionalConfig)))
+                foreach (XElement packageconfigXElement in additionalConfigParents.SelectMany(p => p.Elements(ElementNameAdditionalConfig)))
                 {
                     string? configFileRelativePath = packageconfigXElement.Attribute("name")?.Value;
 
-                    if(string.IsNullOrWhiteSpace(configFileRelativePath))
+                    if (string.IsNullOrWhiteSpace(configFileRelativePath))
                     {
                         Trace.WriteLine($"{InsertionConstants.DefaultConfigFile} lists a .packageconfig under {ElementNameAdditionalConfigsParent} tag, but the .packageconfig has no name.");
                         continue;
                     }
 
                     string configFileAbsolutePath = Path.Combine(configsDirectory, configFileRelativePath).Replace('\\', '/');
-                    
-                    if(!File.Exists(configFileAbsolutePath))
+
+                    if (!File.Exists(configFileAbsolutePath))
                     {
                         Trace.WriteLine($"File for the .packageconfig listed under {InsertionConstants.DefaultConfigFile} was not found on disk. Path: {configFileAbsolutePath}");
                         continue;
@@ -129,8 +129,8 @@ namespace Microsoft.Net.Insertions.Api
                         Trace.WriteLine($"Loading content of .packageconfig at {configFileAbsolutePath}.");
                         packageConfigXDocument = XDocument.Load(configFileAbsolutePath);
                         Trace.WriteLine($"Loaded .packageconfig content.");
-                    } 
-                    catch(Exception e)
+                    }
+                    catch (Exception e)
                     {
                         Trace.WriteLine($"Loading of .packageconfig file has failed with exception{Environment.NewLine}{e.ToString()}");
                         continue;
@@ -182,7 +182,7 @@ namespace Microsoft.Net.Insertions.Api
         /// <remarks>This method is safe to call simultaneously from multiple threads.</remarks>
         public string? GetPackageLink(string packageId)
         {
-            if(!_packageXElements.TryGetValue(packageId, out XElement? xElement))
+            if (!_packageXElements.TryGetValue(packageId, out XElement? xElement))
             {
                 // Package was not found.
                 Trace.WriteLine($"Package {packageId} was not found in default.config/.packageconfig files.");
@@ -210,14 +210,14 @@ namespace Microsoft.Net.Insertions.Api
             FileSaveResult[] results = new FileSaveResult[_modifiedDocuments.Count];
             int arraySaveIndex = 0;
 
-            foreach(XDocument document in _modifiedDocuments.Keys)
+            foreach (XDocument document in _modifiedDocuments.Keys)
             {
                 string savePath = _documentPaths[document];
                 Trace.WriteLine($"Saving modified config file: {savePath}");
                 try
                 {
                     string extension = Path.GetExtension(savePath).ToLowerInvariant();
-                    
+
                     XmlWriterSettings writeSettings = extension == ".packageconfig"
                         ? _packageconfigWriteSettings
                         : _defaultconfigWriteSettings;
@@ -227,7 +227,7 @@ namespace Microsoft.Net.Insertions.Api
                     results[arraySaveIndex++] = new FileSaveResult(savePath);
                     Trace.WriteLine("Save success.");
                 }
-                catch(Exception e)
+                catch (Exception e)
                 {
                     results[arraySaveIndex++] = new FileSaveResult(savePath, e);
                     Trace.WriteLine($"Save failed with exception:{e.ToString()}");

--- a/src/InsertionsClient/Api/IInsertionApi.cs
+++ b/src/InsertionsClient/Api/IInsertionApi.cs
@@ -7,10 +7,10 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("InsertionsClientTest")]
 namespace Microsoft.Net.Insertions.Api
 {
-	/// <summary>
-	/// Defines features to manage default.config insertions from manifest.json.
-	/// </summary>
-	public interface IInsertionApi
+    /// <summary>
+    /// Defines features to manage default.config insertions from manifest.json.
+    /// </summary>
+    public interface IInsertionApi
     {
         /// <summary>
         /// Updates default.config NuGet package versions from matching manifest.json assets.

--- a/src/InsertionsClient/Api/IInsertionApi.cs
+++ b/src/InsertionsClient/Api/IInsertionApi.cs
@@ -4,22 +4,14 @@ using Microsoft.Net.Insertions.Models;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
-[assembly:InternalsVisibleTo("InsertionsClientTest")]
+[assembly: InternalsVisibleTo("InsertionsClientTest")]
 namespace Microsoft.Net.Insertions.Api
 {
-    /// <summary>
-    /// Defines features to manage default.config insertions from manifest.json.
-    /// </summary>
-    public interface IInsertionApi
+	/// <summary>
+	/// Defines features to manage default.config insertions from manifest.json.
+	/// </summary>
+	public interface IInsertionApi
     {
-        /// <summary>
-        /// Updates default.config NuGet package versions from matching manifest.json assets.
-        /// </summary>
-        /// <param name="manifestFile">Specified manifest.json.</param>
-        /// <param name="defaultConfigFile">Full path to &quot;default.config&quot; file.</param>
-        /// <returns><see cref="UpdateResults"/> detailing the operation's outcome.</returns>
-        UpdateResults UpdateVersions(string manifestFile, string defaultConfigFile);
-
         /// <summary>
         /// Updates default.config NuGet package versions from matching manifest.json assets.
         /// </summary>
@@ -27,8 +19,10 @@ namespace Microsoft.Net.Insertions.Api
         /// <param name="defaultConfigFile">Full path to &quot;default.config&quot; file.</param>
         /// <param name="ignoredPackagesFile">Full path to the file which lists all the packages to ignore line by line.
         /// Package ids should be given identical to how they are written in &quot;default.config&quot;.</param>
+        /// <param name="accessToken">Access token used when connecting to nuget feed.</param>
+        /// <param name="propsFilesRootDirectory">Directory that will be searched for props files.</param>
         /// <returns><see cref="UpdateResults"/> detailing the operation's outcome.</returns>
-        UpdateResults UpdateVersions(string manifestFile, string defaultConfigFile, string ignoredPackagesFile);
+        UpdateResults UpdateVersions(string manifestFile, string defaultConfigFile, string ignoredPackagesFile, string? accessToken, string? propsFilesRootDirectory);
 
         /// <summary>
         /// Updates default.config NuGet package versions from matching manifest.json assets.
@@ -36,7 +30,9 @@ namespace Microsoft.Net.Insertions.Api
         /// <param name="manifestFile">Specified manifest.json.</param>
         /// <param name="defaultConfigFile">Full path to &quot;default.config&quot; file.</param>
         /// <param name="packagesToIgnore"><see cref="HashSet{string}"/> of packages to ignore.</param>
+        /// <param name="accessToken">Access token used when connecting to nuget feed.</param>
+        /// <param name="propsFilesRootDirectory">Directory that will be searched for props files.</param>
         /// <returns><see cref="UpdateResults"/> detailing the operation's outcome.</returns>
-        UpdateResults UpdateVersions(string manifestFile, string defaultConfigFile, HashSet<string> packagesToIgnore);
+        UpdateResults UpdateVersions(string manifestFile, string defaultConfigFile, HashSet<string>? packagesToIgnore, string? accessToken, string? propsFilesRootDirectory);
     }
 }

--- a/src/InsertionsClient/Api/IInsertionApiFactory.cs
+++ b/src/InsertionsClient/Api/IInsertionApiFactory.cs
@@ -12,8 +12,10 @@ namespace Microsoft.Net.Insertions.Api
         /// </summary>
         /// <param name="maxWaitSeconds">Optional: Maximum number of seconds that the application
         /// is allowed to run. After that, operation will be cancelled.</param>
+        /// <param name="maxDownloadSeconds">Optional: Maximum number of seconds that the application
+        /// is allowed to spend on downloading and processing nuget packages.</param>
         /// <param name="maxConcurrency">Optional: Level of concurrency.</param>
         /// <returns><see cref="IInsertionApi"/> An IInsertionApi instance.</returns>
-        IInsertionApi Create(int? maxWaitSeconds = null, int? maxConcurrency = null);
+        IInsertionApi Create(int? maxWaitSeconds = null, int? maxDownloadSeconds = null, int? maxConcurrency = null);
     }
 }

--- a/src/InsertionsClient/Api/Props/Models/PayloadPath.cs
+++ b/src/InsertionsClient/Api/Props/Models/PayloadPath.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Net.Insertions.Api.Props.Models
+{
+    /// <summary>
+    /// Represents a payload defined in the swr file.
+    /// </summary>
+    internal class PayloadPath
+    {
+        /// <summary>
+        /// Pattern that will match the path to an actual file on disk, exposing the value of the variable.
+        /// Precompiled to allow efficient reuse.
+        /// </summary>
+        public Regex Pattern { get; private set; }
+
+        /// <summary>
+        /// Name of the variable referenced in the path.
+        /// </summary>
+        public string VariableName { get; private set; }
+
+        /// <summary>
+        /// Creates an instance of <see cref="PayloadPath"/>
+        /// </summary>
+        /// <param name="pattern">Pattern that will match the path to an actual file on disk, 
+        ///	exposing the value of the variable.</param>
+        /// <param name="variableName">Name of the variable, referenced in the path</param>
+        internal PayloadPath(Regex pattern, string variableName)
+        {
+            Pattern = pattern;
+            VariableName = variableName;
+        }
+    }
+}

--- a/src/InsertionsClient/Api/Props/Models/PropsFile.cs
+++ b/src/InsertionsClient/Api/Props/Models/PropsFile.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Net.Insertions.Props.Models
             catch (Exception e)
             {
                 Trace.WriteLine($"Failed to load xml document at path: {Path}");
-                Trace.WriteLine(e.Message);
+                Trace.WriteLine(e.ToString());
                 return false;
             }
         }

--- a/src/InsertionsClient/Api/Props/Models/PropsFile.cs
+++ b/src/InsertionsClient/Api/Props/Models/PropsFile.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Net.Insertions.Props.Models
 				}
 
 				XText textNode = (XText)node;
-				var textValue = textNode.Value;
+				string textValue = textNode.Value;
 				foreach (Match? match in _variableAssignmentRegex.Matches(textNode.Value))
 				{
 					if(match!.Groups[1].Value == variableName)

--- a/src/InsertionsClient/Api/Props/Models/PropsFile.cs
+++ b/src/InsertionsClient/Api/Props/Models/PropsFile.cs
@@ -85,9 +85,7 @@ namespace Microsoft.Net.Insertions.Props.Models
 						}
 
 						isDirty = true;
-						textNode.Value = textValue.Substring(0, match.Index) +
-							variableName + "=" + value +
-							textValue.Substring(match.Index + match.Length);
+						textNode.Value = $"{textValue.Substring(0, match.Index)}{variableName}={value};{textValue.Substring(match.Index + match.Length)}";
 						return true;
 					}
 				}

--- a/src/InsertionsClient/Api/Props/Models/PropsFile.cs
+++ b/src/InsertionsClient/Api/Props/Models/PropsFile.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Net.Insertions.Props.Models
         /// <summary>
         /// Has content of this file changes since we loaded it?
         /// </summary>
-        public bool isDirty { get; private set; }
+        internal bool isDirty { get; private set; }
 
         private XDocument? _xDocument { get; set; }
 
@@ -53,7 +53,7 @@ namespace Microsoft.Net.Insertions.Props.Models
         /// <param name="value">New value of the variable</param>
         /// <param name="value">Previous value of the variable, if found.</param>
         /// <returns>True if variable was found. False otherwise</returns>
-        public bool TryUpdateVariable(string variableName, string value, out string existingValue)
+        internal bool TryUpdateVariable(string variableName, string value, out string existingValue)
         {
             if (!_isLoaded && !LoadDocument())
             {
@@ -103,7 +103,7 @@ namespace Microsoft.Net.Insertions.Props.Models
         /// file to disk. If there are no changes to the file and no
         /// disk operation is needed, returns null value.
         /// </returns>
-        public FileSaveResult? Save()
+        internal FileSaveResult? Save()
         {
             if (_isLoaded == false || !isDirty)
             {

--- a/src/InsertionsClient/Api/Props/Models/PropsFile.cs
+++ b/src/InsertionsClient/Api/Props/Models/PropsFile.cs
@@ -14,8 +14,24 @@ namespace Microsoft.Net.Insertions.Props.Models
     /// This type represents a props file that contains the variables
     /// to be used during VS build process.
     /// </summary>
-    public class PropsFile
+    public sealed class PropsFile
     {
+        /// <summary>
+        /// Matches a variable assignement line.
+        /// First matched group is the variable name, second one is the value.
+        /// </summary>
+        /// <example>NetCoreSharedHostVersion=3.1.2;</example>
+        private static Regex _variableAssignmentRegex = new Regex(@"\b(\w*)=([\w|.|-]*);");
+
+        /// <summary>
+        /// Creates an instance of PropsFile.
+        /// </summary>
+        /// <param name="path">Path to the file on disk.</param>
+        internal PropsFile(string path)
+        {
+            Path = path;
+        }
+
         /// <summary>
         /// Path to this file on disk.
         /// </summary>
@@ -29,22 +45,6 @@ namespace Microsoft.Net.Insertions.Props.Models
         private XDocument? _xDocument { get; set; }
 
         private bool _isLoaded => _xDocument != null;
-
-        /// <summary>
-        /// Matches a variable assignement line.
-        /// First matched group is the variable name, second one is the value.
-        /// </summary>
-        /// <example>NetCoreSharedHostVersion=3.1.2;</example>
-        private static Regex _variableAssignmentRegex = new Regex(@"\b(\w*)=([\w|.|-]*);");
-
-        /// <summary>
-        /// Creates an instance of PropsFile.
-        /// </summary>
-        /// <param name="path">Path to the file on disk.</param>
-        public PropsFile(string path)
-        {
-            Path = path;
-        }
 
         /// <summary>
         /// Attempts to find given variable in the file. Changes the value if found.

--- a/src/InsertionsClient/Api/Props/Models/PropsFile.cs
+++ b/src/InsertionsClient/Api/Props/Models/PropsFile.cs
@@ -1,0 +1,150 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Net.Insertions.Models;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace Microsoft.Net.Insertions.Props.Models
+{
+	/// <summary>
+	/// This type represents a props file that contains the variables
+	/// to be used during VS build process.
+	/// </summary>
+	public class PropsFile
+	{
+		/// <summary>
+		/// Path to this file on disk.
+		/// </summary>
+		public string Path { get; private set; }
+
+		/// <summary>
+		/// Has content of this file changes since we loaded it?
+		/// </summary>
+		public bool isDirty { get; private set; }
+
+		private XDocument? _xDocument { get; set; }
+
+		private bool _isLoaded => _xDocument != null;
+
+		/// <summary>
+		/// Matches a variable assignement line.
+		/// First matched group is the variable name, second one is the value.
+		/// </summary>
+		/// <example>NetCoreSharedHostVersion=3.1.2;</example>
+		private static Regex _variableAssignmentRegex = new Regex(@"\b(\w*)=([\w|.|-]*);");
+
+		/// <summary>
+		/// Creates an instance of PropsFile.
+		/// </summary>
+		/// <param name="path">Path to the file on disk.</param>
+		public PropsFile(string path)
+		{
+			Path = path;
+		}
+
+		/// <summary>
+		/// Attempts to find given variable in the file. Changes the value if found.
+		/// </summary>
+		/// <param name="variableName">Name of the variable to change</param>
+		/// <param name="value">New value of the variable</param>
+		/// <param name="value">Previous value of the variable, if found.</param>
+		/// <returns>True if variable was found. False otherwise</returns>
+		public bool TryUpdateVariable(string variableName, string value, out string existingValue)
+		{
+			if (!_isLoaded && !LoadDocument())
+			{
+				Trace.WriteLine($"Updating variable \"{variableName}\" has failed.");
+				existingValue = string.Empty;
+				return false;
+			}
+
+			foreach(XNode node in _xDocument!.Descendants(_xDocument.Root.Name.Namespace + "PackagePreprocessorDefinitions").Nodes())
+			{
+				if (node.NodeType != XmlNodeType.Text)
+				{
+					// PreprocessorDefinitions are always defined in text nodes.
+					continue;
+				}
+
+				XText textNode = (XText)node;
+				var textValue = textNode.Value;
+				foreach (Match? match in _variableAssignmentRegex.Matches(textNode.Value))
+				{
+					if(match!.Groups[1].Value == variableName)
+					{
+						existingValue = match!.Groups[2].Value;
+
+						if(existingValue == value)
+						{
+							// Value is the same, no need to set dirty.
+							return true;
+						}
+
+						isDirty = true;
+						textNode.Value = textValue.Substring(0, match.Index) +
+							variableName + "=" + value +
+							textValue.Substring(match.Index + match.Length);
+						return true;
+					}
+				}
+			}
+
+			existingValue = string.Empty;
+			return false;
+		}
+
+		/// <summary>
+		/// Saves the XmlDocument back to disk.
+		/// </summary>
+		/// <returns>The result of the operation.
+		/// An instance is returned if there was an attempt to save 
+		/// file to disk. If there are no changes to the file and no
+		/// disk operation is needed, returns null value.
+		/// </returns>
+		public FileSaveResult? Save()
+		{
+			if (_isLoaded == false || !isDirty)
+			{
+				// We don't have a better data in memory
+				// Data on the disk is already what is expected. Consider this done.
+				return null;
+			}
+
+			try
+			{
+				_xDocument!.Save(Path);
+				return new FileSaveResult(Path);
+			}
+			catch (Exception e)
+			{
+				return new FileSaveResult(Path, e);
+			}
+		}
+
+		private bool LoadDocument()
+		{
+			if (!File.Exists(Path))
+			{
+				Trace.WriteLine($"Props file does not exist at location: {Path}");
+				return false;
+			}
+
+			try
+			{
+				_xDocument = XDocument.Load(Path);
+				isDirty = false;
+				return true;
+			}
+			catch (Exception e)
+			{
+				Trace.WriteLine($"Failed to load xml document at path: {Path}");
+				Trace.WriteLine(e.Message);
+				return false;
+			}
+		}
+	}
+}

--- a/src/InsertionsClient/Api/Props/Models/PropsFile.cs
+++ b/src/InsertionsClient/Api/Props/Models/PropsFile.cs
@@ -10,139 +10,139 @@ using System.Xml.Linq;
 
 namespace Microsoft.Net.Insertions.Props.Models
 {
-	/// <summary>
-	/// This type represents a props file that contains the variables
-	/// to be used during VS build process.
-	/// </summary>
-	public class PropsFile
-	{
-		/// <summary>
-		/// Path to this file on disk.
-		/// </summary>
-		public string Path { get; private set; }
+    /// <summary>
+    /// This type represents a props file that contains the variables
+    /// to be used during VS build process.
+    /// </summary>
+    public class PropsFile
+    {
+        /// <summary>
+        /// Path to this file on disk.
+        /// </summary>
+        public string Path { get; private set; }
 
-		/// <summary>
-		/// Has content of this file changes since we loaded it?
-		/// </summary>
-		public bool isDirty { get; private set; }
+        /// <summary>
+        /// Has content of this file changes since we loaded it?
+        /// </summary>
+        public bool isDirty { get; private set; }
 
-		private XDocument? _xDocument { get; set; }
+        private XDocument? _xDocument { get; set; }
 
-		private bool _isLoaded => _xDocument != null;
+        private bool _isLoaded => _xDocument != null;
 
-		/// <summary>
-		/// Matches a variable assignement line.
-		/// First matched group is the variable name, second one is the value.
-		/// </summary>
-		/// <example>NetCoreSharedHostVersion=3.1.2;</example>
-		private static Regex _variableAssignmentRegex = new Regex(@"\b(\w*)=([\w|.|-]*);");
+        /// <summary>
+        /// Matches a variable assignement line.
+        /// First matched group is the variable name, second one is the value.
+        /// </summary>
+        /// <example>NetCoreSharedHostVersion=3.1.2;</example>
+        private static Regex _variableAssignmentRegex = new Regex(@"\b(\w*)=([\w|.|-]*);");
 
-		/// <summary>
-		/// Creates an instance of PropsFile.
-		/// </summary>
-		/// <param name="path">Path to the file on disk.</param>
-		public PropsFile(string path)
-		{
-			Path = path;
-		}
+        /// <summary>
+        /// Creates an instance of PropsFile.
+        /// </summary>
+        /// <param name="path">Path to the file on disk.</param>
+        public PropsFile(string path)
+        {
+            Path = path;
+        }
 
-		/// <summary>
-		/// Attempts to find given variable in the file. Changes the value if found.
-		/// </summary>
-		/// <param name="variableName">Name of the variable to change</param>
-		/// <param name="value">New value of the variable</param>
-		/// <param name="value">Previous value of the variable, if found.</param>
-		/// <returns>True if variable was found. False otherwise</returns>
-		public bool TryUpdateVariable(string variableName, string value, out string existingValue)
-		{
-			if (!_isLoaded && !LoadDocument())
-			{
-				Trace.WriteLine($"Updating variable \"{variableName}\" has failed.");
-				existingValue = string.Empty;
-				return false;
-			}
+        /// <summary>
+        /// Attempts to find given variable in the file. Changes the value if found.
+        /// </summary>
+        /// <param name="variableName">Name of the variable to change</param>
+        /// <param name="value">New value of the variable</param>
+        /// <param name="value">Previous value of the variable, if found.</param>
+        /// <returns>True if variable was found. False otherwise</returns>
+        public bool TryUpdateVariable(string variableName, string value, out string existingValue)
+        {
+            if (!_isLoaded && !LoadDocument())
+            {
+                Trace.WriteLine($"Updating variable \"{variableName}\" has failed.");
+                existingValue = string.Empty;
+                return false;
+            }
 
-			foreach(XNode node in _xDocument!.Descendants(_xDocument.Root.Name.Namespace + "PackagePreprocessorDefinitions").Nodes())
-			{
-				if (node.NodeType != XmlNodeType.Text)
-				{
-					// PreprocessorDefinitions are always defined in text nodes.
-					continue;
-				}
+            foreach (XNode node in _xDocument!.Descendants(_xDocument.Root.Name.Namespace + "PackagePreprocessorDefinitions").Nodes())
+            {
+                if (node.NodeType != XmlNodeType.Text)
+                {
+                    // PreprocessorDefinitions are always defined in text nodes.
+                    continue;
+                }
 
-				XText textNode = (XText)node;
-				string textValue = textNode.Value;
-				foreach (Match? match in _variableAssignmentRegex.Matches(textNode.Value))
-				{
-					if(match!.Groups[1].Value == variableName)
-					{
-						existingValue = match!.Groups[2].Value;
+                XText textNode = (XText)node;
+                string textValue = textNode.Value;
+                foreach (Match? match in _variableAssignmentRegex.Matches(textNode.Value))
+                {
+                    if (match!.Groups[1].Value == variableName)
+                    {
+                        existingValue = match!.Groups[2].Value;
 
-						if(existingValue == value)
-						{
-							// Value is the same, no need to set dirty.
-							return true;
-						}
+                        if (existingValue == value)
+                        {
+                            // Value is the same, no need to set dirty.
+                            return true;
+                        }
 
-						isDirty = true;
-						textNode.Value = $"{textValue.Substring(0, match.Index)}{variableName}={value};{textValue.Substring(match.Index + match.Length)}";
-						return true;
-					}
-				}
-			}
+                        isDirty = true;
+                        textNode.Value = $"{textValue.Substring(0, match.Index)}{variableName}={value};{textValue.Substring(match.Index + match.Length)}";
+                        return true;
+                    }
+                }
+            }
 
-			existingValue = string.Empty;
-			return false;
-		}
+            existingValue = string.Empty;
+            return false;
+        }
 
-		/// <summary>
-		/// Saves the XmlDocument back to disk.
-		/// </summary>
-		/// <returns>The result of the operation.
-		/// An instance is returned if there was an attempt to save 
-		/// file to disk. If there are no changes to the file and no
-		/// disk operation is needed, returns null value.
-		/// </returns>
-		public FileSaveResult? Save()
-		{
-			if (_isLoaded == false || !isDirty)
-			{
-				// We don't have a better data in memory
-				// Data on the disk is already what is expected. Consider this done.
-				return null;
-			}
+        /// <summary>
+        /// Saves the XmlDocument back to disk.
+        /// </summary>
+        /// <returns>The result of the operation.
+        /// An instance is returned if there was an attempt to save 
+        /// file to disk. If there are no changes to the file and no
+        /// disk operation is needed, returns null value.
+        /// </returns>
+        public FileSaveResult? Save()
+        {
+            if (_isLoaded == false || !isDirty)
+            {
+                // We don't have a better data in memory
+                // Data on the disk is already what is expected. Consider this done.
+                return null;
+            }
 
-			try
-			{
-				_xDocument!.Save(Path);
-				return new FileSaveResult(Path);
-			}
-			catch (Exception e)
-			{
-				return new FileSaveResult(Path, e);
-			}
-		}
+            try
+            {
+                _xDocument!.Save(Path);
+                return new FileSaveResult(Path);
+            }
+            catch (Exception e)
+            {
+                return new FileSaveResult(Path, e);
+            }
+        }
 
-		private bool LoadDocument()
-		{
-			if (!File.Exists(Path))
-			{
-				Trace.WriteLine($"Props file does not exist at location: {Path}");
-				return false;
-			}
+        private bool LoadDocument()
+        {
+            if (!File.Exists(Path))
+            {
+                Trace.WriteLine($"Props file does not exist at location: {Path}");
+                return false;
+            }
 
-			try
-			{
-				_xDocument = XDocument.Load(Path);
-				isDirty = false;
-				return true;
-			}
-			catch (Exception e)
-			{
-				Trace.WriteLine($"Failed to load xml document at path: {Path}");
-				Trace.WriteLine(e.Message);
-				return false;
-			}
-		}
-	}
+            try
+            {
+                _xDocument = XDocument.Load(Path);
+                isDirty = false;
+                return true;
+            }
+            catch (Exception e)
+            {
+                Trace.WriteLine($"Failed to load xml document at path: {Path}");
+                Trace.WriteLine(e.Message);
+                return false;
+            }
+        }
+    }
 }

--- a/src/InsertionsClient/Api/Props/Models/PropsFileVariableReference.cs
+++ b/src/InsertionsClient/Api/Props/Models/PropsFileVariableReference.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Net.Insertions.Props.Models
     /// <summary>
     /// Represents a reference to a variable defined in a props file
     /// </summary>
-    public class PropsFileVariableReference
+    public sealed class PropsFileVariableReference
     {
         /// <summary>
         /// Name of the defined variable
@@ -23,14 +23,13 @@ namespace Microsoft.Net.Insertions.Props.Models
         /// </summary>
         public string ReferencedFilePath { get; private set; }
 
-
         /// <summary>
         /// Creates an instance of <see cref="PropsFileVariableReference"/>.
         /// </summary>
         /// <param name="name">Name of the variable</param>
         /// <param name="value">Desired value of the variable</param>
         /// <param name="referencedFilePath">The file that was referencing this variable.</param>
-        public PropsFileVariableReference(string name, string value, string referencedFilePath)
+        internal PropsFileVariableReference(string name, string value, string referencedFilePath)
         {
             Name = name;
             Value = value;

--- a/src/InsertionsClient/Api/Props/Models/PropsFileVariableReference.cs
+++ b/src/InsertionsClient/Api/Props/Models/PropsFileVariableReference.cs
@@ -2,39 +2,39 @@
 
 namespace Microsoft.Net.Insertions.Props.Models
 {
-	/// <summary>
-	/// Represents a reference to a variable defined in a props file
-	/// </summary>
-	public class PropsFileVariableReference
-	{
-		/// <summary>
-		/// Name of the defined variable
-		/// </summary>
-		public string Name { get; private set; }
+    /// <summary>
+    /// Represents a reference to a variable defined in a props file
+    /// </summary>
+    public class PropsFileVariableReference
+    {
+        /// <summary>
+        /// Name of the defined variable
+        /// </summary>
+        public string Name { get; private set; }
 
-		/// <summary>
-		/// Desired value of the variable
-		/// </summary>
-		public string Value { get; private set; }
+        /// <summary>
+        /// Desired value of the variable
+        /// </summary>
+        public string Value { get; private set; }
 
-		/// <summary>
-		/// The file that was referencing this variable. Used when resolving the correct scope
-		/// for the variable.
-		/// </summary>
-		public string ReferencedFilePath { get; private set; }
+        /// <summary>
+        /// The file that was referencing this variable. Used when resolving the correct scope
+        /// for the variable.
+        /// </summary>
+        public string ReferencedFilePath { get; private set; }
 
 
-		/// <summary>
-		/// Creates an instance of <see cref="PropsFileVariableReference"/>.
-		/// </summary>
-		/// <param name="name">Name of the variable</param>
-		/// <param name="value">Desired value of the variable</param>
-		/// <param name="referencedFilePath">The file that was referencing this variable.</param>
-		public PropsFileVariableReference(string name, string value, string referencedFilePath)
-		{
-			Name = name;
-			Value = value;
-			ReferencedFilePath = referencedFilePath;
-		}
-	}
+        /// <summary>
+        /// Creates an instance of <see cref="PropsFileVariableReference"/>.
+        /// </summary>
+        /// <param name="name">Name of the variable</param>
+        /// <param name="value">Desired value of the variable</param>
+        /// <param name="referencedFilePath">The file that was referencing this variable.</param>
+        public PropsFileVariableReference(string name, string value, string referencedFilePath)
+        {
+            Name = name;
+            Value = value;
+            ReferencedFilePath = referencedFilePath;
+        }
+    }
 }

--- a/src/InsertionsClient/Api/Props/Models/PropsFileVariableReference.cs
+++ b/src/InsertionsClient/Api/Props/Models/PropsFileVariableReference.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.Net.Insertions.Props.Models
+{
+	/// <summary>
+	/// Represents a reference to a variable defined in a props file
+	/// </summary>
+	public class PropsFileVariableReference
+	{
+		/// <summary>
+		/// Name of the defined variable
+		/// </summary>
+		public string Name { get; private set; }
+
+		/// <summary>
+		/// Desired value of the variable
+		/// </summary>
+		public string Value { get; private set; }
+
+		/// <summary>
+		/// The file that was referencing this variable. Used when resolving the correct scope
+		/// for the variable.
+		/// </summary>
+		public string ReferencedFilePath { get; private set; }
+
+
+		/// <summary>
+		/// Creates an instance of <see cref="PropsFileVariableReference"/>.
+		/// </summary>
+		/// <param name="name">Name of the variable</param>
+		/// <param name="value">Desired value of the variable</param>
+		/// <param name="referencedFilePath">The file that was referencing this variable.</param>
+		public PropsFileVariableReference(string name, string value, string referencedFilePath)
+		{
+			Name = name;
+			Value = value;
+			ReferencedFilePath = referencedFilePath;
+		}
+	}
+}

--- a/src/InsertionsClient/Api/Props/Models/PropsUpdateResults.cs
+++ b/src/InsertionsClient/Api/Props/Models/PropsUpdateResults.cs
@@ -8,8 +8,14 @@ namespace Microsoft.Net.Insertions.Props.Models
     /// <summary>
     /// Represents the result of a PropsFile update operation
     /// </summary>
-    public class PropsUpdateResults
+    public sealed class PropsUpdateResults
     {
+        internal readonly List<PropsFileVariableReference> _unrecognizedVariables = new List<PropsFileVariableReference>();
+
+        internal readonly Dictionary<PropsFile, List<PropsFileVariableReference>> _updatedVariables = new Dictionary<PropsFile, List<PropsFileVariableReference>>();
+
+        internal readonly List<FileSaveResult> _modifiedFiles = new List<FileSaveResult>();
+
         /// <summary>
         /// Overall result of the update operation.
         /// True for success, false for failure.
@@ -24,16 +30,16 @@ namespace Microsoft.Net.Insertions.Props.Models
         /// <summary>
         /// Variables that were requested to be changed, but wasn't found in any of the props files.
         /// </summary>
-        public List<PropsFileVariableReference> UnrecognizedVariables { get; private set; } = new List<PropsFileVariableReference>();
+        public IReadOnlyList<PropsFileVariableReference> UnrecognizedVariables => _unrecognizedVariables;
 
         /// <summary>
         /// Variables that were successfully found and modified, keyed by the <see cref="PropsFile"/> that stores them.
         /// </summary>
-        public Dictionary<PropsFile, List<PropsFileVariableReference>> UpdatedVariables { get; private set; } = new Dictionary<PropsFile, List<PropsFileVariableReference>>();
+        public IReadOnlyDictionary<PropsFile, List<PropsFileVariableReference>> UpdatedVariables => _updatedVariables;
 
         /// <summary>
         /// Result of each operation that attempted to save a <see cref="PropsFile"/> to disk.
         /// </summary>
-        public List<FileSaveResult> ModifiedFiles { get; set; } = new List<FileSaveResult>();
+        public IReadOnlyList<FileSaveResult> ModifiedFiles => _modifiedFiles;
     }
 }

--- a/src/InsertionsClient/Api/Props/Models/PropsUpdateResults.cs
+++ b/src/InsertionsClient/Api/Props/Models/PropsUpdateResults.cs
@@ -5,35 +5,35 @@ using System.Collections.Generic;
 
 namespace Microsoft.Net.Insertions.Props.Models
 {
-	/// <summary>
-	/// Represents the result of a PropsFile update operation
-	/// </summary>
-	public class PropsUpdateResults
-	{
-		/// <summary>
-		/// Overall result of the update operation.
-		/// True for success, false for failure.
-		/// </summary>
-		public bool Outcome { get; set; }
+    /// <summary>
+    /// Represents the result of a PropsFile update operation
+    /// </summary>
+    public class PropsUpdateResults
+    {
+        /// <summary>
+        /// Overall result of the update operation.
+        /// True for success, false for failure.
+        /// </summary>
+        public bool Outcome { get; set; }
 
-		/// <summary>
-		/// Text, explaining the reasoning behind the outcome.
-		/// </summary>
-		public string? OutcomeDetails { get; set; }
+        /// <summary>
+        /// Text, explaining the reasoning behind the outcome.
+        /// </summary>
+        public string? OutcomeDetails { get; set; }
 
-		/// <summary>
-		/// Variables that were requested to be changed, but wasn't found in any of the props files.
-		/// </summary>
-		public List<PropsFileVariableReference> UnrecognizedVariables { get; private set; } = new List<PropsFileVariableReference>();
+        /// <summary>
+        /// Variables that were requested to be changed, but wasn't found in any of the props files.
+        /// </summary>
+        public List<PropsFileVariableReference> UnrecognizedVariables { get; private set; } = new List<PropsFileVariableReference>();
 
-		/// <summary>
-		/// Variables that were successfully found and modified, keyed by the <see cref="PropsFile"/> that stores them.
-		/// </summary>
-		public Dictionary<PropsFile, List<PropsFileVariableReference>> UpdatedVariables { get; private set; } = new Dictionary<PropsFile, List<PropsFileVariableReference>>();
+        /// <summary>
+        /// Variables that were successfully found and modified, keyed by the <see cref="PropsFile"/> that stores them.
+        /// </summary>
+        public Dictionary<PropsFile, List<PropsFileVariableReference>> UpdatedVariables { get; private set; } = new Dictionary<PropsFile, List<PropsFileVariableReference>>();
 
-		/// <summary>
-		/// Result of each operation that attempted to save a <see cref="PropsFile"/> to disk.
-		/// </summary>
-		public List<FileSaveResult> ModifiedFiles { get; set; } = new List<FileSaveResult>();
-	}
+        /// <summary>
+        /// Result of each operation that attempted to save a <see cref="PropsFile"/> to disk.
+        /// </summary>
+        public List<FileSaveResult> ModifiedFiles { get; set; } = new List<FileSaveResult>();
+    }
 }

--- a/src/InsertionsClient/Api/Props/Models/PropsUpdateResults.cs
+++ b/src/InsertionsClient/Api/Props/Models/PropsUpdateResults.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Net.Insertions.Models;
+using System.Collections.Generic;
+
+namespace Microsoft.Net.Insertions.Props.Models
+{
+	/// <summary>
+	/// Represents the result of a PropsFile update operation
+	/// </summary>
+	public class PropsUpdateResults
+	{
+		/// <summary>
+		/// Overall result of the update operation.
+		/// True for success, false for failure.
+		/// </summary>
+		public bool Outcome { get; set; }
+
+		/// <summary>
+		/// Text, explaining the reasoning behind the outcome.
+		/// </summary>
+		public string? OutcomeDetails { get; set; }
+
+		/// <summary>
+		/// Variables that were requested to be changed, but wasn't found in any of the props files.
+		/// </summary>
+		public List<PropsFileVariableReference> UnrecognizedVariables { get; private set; } = new List<PropsFileVariableReference>();
+
+		/// <summary>
+		/// Variables that were successfully found and modified, keyed by the <see cref="PropsFile"/> that stores them.
+		/// </summary>
+		public Dictionary<PropsFile, List<PropsFileVariableReference>> UpdatedVariables { get; private set; } = new Dictionary<PropsFile, List<PropsFileVariableReference>>();
+
+		/// <summary>
+		/// Result of each operation that attempted to save a <see cref="PropsFile"/> to disk.
+		/// </summary>
+		public List<FileSaveResult> ModifiedFiles { get; set; } = new List<FileSaveResult>();
+	}
+}

--- a/src/InsertionsClient/Api/Props/Models/SwrFile.cs
+++ b/src/InsertionsClient/Api/Props/Models/SwrFile.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 
-namespace Microsoft.Net.Insertions.Api.Models
+namespace Microsoft.Net.Insertions.Api.Props.Models
 {
     /// <summary>
     /// Represents an SWR file in a VS repo local working directory.
@@ -28,35 +27,6 @@ namespace Microsoft.Net.Insertions.Api.Models
         public SwrFile(string path)
         {
             Path = path;
-        }
-
-        /// <summary>
-        /// Represents a payload defined in the swr file.
-        /// </summary>
-        public class PayloadPath
-        {
-            /// <summary>
-            /// Pattern that will match the path to an actual file on disk, exposing the value of the variable.
-            /// Precompiled to allow efficient reuse.
-            /// </summary>
-            public readonly Regex Pattern;
-
-            /// <summary>
-            /// Name of the variable referenced in the path.
-            /// </summary>
-            public readonly string VariableName;
-
-            /// <summary>
-            /// Creates an instance of <see cref="PayloadPath"/>
-            /// </summary>
-            /// <param name="pattern">Pattern that will match the path to an actual file on disk, 
-            ///	exposing the value of the variable.</param>
-            /// <param name="variableName">Name of the variable, referenced in the path</param>
-            public PayloadPath(Regex pattern, string variableName)
-            {
-                Pattern = pattern;
-                VariableName = variableName;
-            }
         }
     }
 }

--- a/src/InsertionsClient/Api/Props/Models/SwrFile.cs
+++ b/src/InsertionsClient/Api/Props/Models/SwrFile.cs
@@ -5,58 +5,58 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Net.Insertions.Api.Models
 {
-	/// <summary>
-	/// Represents an SWR file in a VS repo local working directory.
-	/// </summary>
-	internal class SwrFile
-	{
-		/// <summary>
-		/// Full path to the swr file.
-		/// </summary>
-		public readonly string Path;
+    /// <summary>
+    /// Represents an SWR file in a VS repo local working directory.
+    /// </summary>
+    internal class SwrFile
+    {
+        /// <summary>
+        /// Full path to the swr file.
+        /// </summary>
+        public readonly string Path;
 
-		/// <summary>
-		/// Paths to payloads mentioned in the file.
-		/// </summary>
-		public readonly List<PayloadPath> PayloadPaths = new List<PayloadPath>();
+        /// <summary>
+        /// Paths to payloads mentioned in the file.
+        /// </summary>
+        public readonly List<PayloadPath> PayloadPaths = new List<PayloadPath>();
 
-		/// <summary>
-		/// Represents a payload defined in the swr file.
-		/// </summary>
-		public class PayloadPath
-		{
-			/// <summary>
-			/// Pattern that will match the path to an actual file on disk, exposing the value of the variable.
-			/// Precompiled to allow efficient reuse.
-			/// </summary>
-			public readonly Regex Pattern;
+        /// <summary>
+        /// Represents a payload defined in the swr file.
+        /// </summary>
+        public class PayloadPath
+        {
+            /// <summary>
+            /// Pattern that will match the path to an actual file on disk, exposing the value of the variable.
+            /// Precompiled to allow efficient reuse.
+            /// </summary>
+            public readonly Regex Pattern;
 
-			/// <summary>
-			/// Name of the variable referenced in the path.
-			/// </summary>
-			public readonly string VariableName;
+            /// <summary>
+            /// Name of the variable referenced in the path.
+            /// </summary>
+            public readonly string VariableName;
 
-			/// <summary>
-			/// Creates an instance of <see cref="PayloadPath"/>
-			/// </summary>
-			/// <param name="pattern">Pattern that will match the path to an actual file on disk, 
-			///	exposing the value of the variable.</param>
-			/// <param name="variableName">Name of the variable, referenced in the path</param>
-			public PayloadPath(Regex pattern, string variableName)
-			{
-				Pattern = pattern;
-				VariableName = variableName;
-			}
-		}
+            /// <summary>
+            /// Creates an instance of <see cref="PayloadPath"/>
+            /// </summary>
+            /// <param name="pattern">Pattern that will match the path to an actual file on disk, 
+            ///	exposing the value of the variable.</param>
+            /// <param name="variableName">Name of the variable, referenced in the path</param>
+            public PayloadPath(Regex pattern, string variableName)
+            {
+                Pattern = pattern;
+                VariableName = variableName;
+            }
+        }
 
-		/// <summary>
-		/// Creates an instance of <see cref="SwrFile"/>.
-		/// Doesn't access the file, only stores the path.
-		/// </summary>
-		/// <param name="path">Path to the file on disk</param>
-		public SwrFile(string path)
-		{
-			Path = path;
-		}
-	}
+        /// <summary>
+        /// Creates an instance of <see cref="SwrFile"/>.
+        /// Doesn't access the file, only stores the path.
+        /// </summary>
+        /// <param name="path">Path to the file on disk</param>
+        public SwrFile(string path)
+        {
+            Path = path;
+        }
+    }
 }

--- a/src/InsertionsClient/Api/Props/Models/SwrFile.cs
+++ b/src/InsertionsClient/Api/Props/Models/SwrFile.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Net.Insertions.Api.Models
     /// <summary>
     /// Represents an SWR file in a VS repo local working directory.
     /// </summary>
-    internal class SwrFile
+    internal sealed class SwrFile
     {
         /// <summary>
         /// Full path to the swr file.
@@ -19,6 +19,16 @@ namespace Microsoft.Net.Insertions.Api.Models
         /// Paths to payloads mentioned in the file.
         /// </summary>
         public readonly List<PayloadPath> PayloadPaths = new List<PayloadPath>();
+
+        /// <summary>
+        /// Creates an instance of <see cref="SwrFile"/>.
+        /// Doesn't access the file, only stores the path.
+        /// </summary>
+        /// <param name="path">Path to the file on disk</param>
+        public SwrFile(string path)
+        {
+            Path = path;
+        }
 
         /// <summary>
         /// Represents a payload defined in the swr file.
@@ -47,16 +57,6 @@ namespace Microsoft.Net.Insertions.Api.Models
                 Pattern = pattern;
                 VariableName = variableName;
             }
-        }
-
-        /// <summary>
-        /// Creates an instance of <see cref="SwrFile"/>.
-        /// Doesn't access the file, only stores the path.
-        /// </summary>
-        /// <param name="path">Path to the file on disk</param>
-        public SwrFile(string path)
-        {
-            Path = path;
         }
     }
 }

--- a/src/InsertionsClient/Api/Props/Models/SwrFile.cs
+++ b/src/InsertionsClient/Api/Props/Models/SwrFile.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Net.Insertions.Api.Models
+{
+	/// <summary>
+	/// Represents an SWR file in a VS repo local working directory.
+	/// </summary>
+	internal class SwrFile
+	{
+		/// <summary>
+		/// Full path to the swr file.
+		/// </summary>
+		public readonly string Path;
+
+		/// <summary>
+		/// Paths to payloads mentioned in the file.
+		/// </summary>
+		public readonly List<PayloadPath> PayloadPaths = new List<PayloadPath>();
+
+		/// <summary>
+		/// Represents a payload defined in the swr file.
+		/// </summary>
+		public class PayloadPath
+		{
+			/// <summary>
+			/// Pattern that will match the path to an actual file on disk, exposing the value of the variable.
+			/// Precompiled to allow efficient reuse.
+			/// </summary>
+			public readonly Regex Pattern;
+
+			/// <summary>
+			/// Name of the variable referenced in the path.
+			/// </summary>
+			public readonly string VariableName;
+
+			/// <summary>
+			/// Creates an instance of <see cref="PayloadPath"/>
+			/// </summary>
+			/// <param name="pattern">Pattern that will match the path to an actual file on disk, 
+			///	exposing the value of the variable.</param>
+			/// <param name="variableName">Name of the variable, referenced in the path</param>
+			public PayloadPath(Regex pattern, string variableName)
+			{
+				Pattern = pattern;
+				VariableName = variableName;
+			}
+		}
+
+		/// <summary>
+		/// Creates an instance of <see cref="SwrFile"/>
+		/// </summary>
+		/// <param name="path">Path to the file on disk</param>
+		public SwrFile(string path)
+		{
+			Path = path;
+		}
+	}
+}

--- a/src/InsertionsClient/Api/Props/Models/SwrFile.cs
+++ b/src/InsertionsClient/Api/Props/Models/SwrFile.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Net.Insertions.Api.Models
 		}
 
 		/// <summary>
-		/// Creates an instance of <see cref="SwrFile"/>
+		/// Creates an instance of <see cref="SwrFile"/>.
+		/// Doesn't access the file, only stores the path.
 		/// </summary>
 		/// <param name="path">Path to the file on disk</param>
 		public SwrFile(string path)

--- a/src/InsertionsClient/Api/Props/PropsFileUpdater.cs
+++ b/src/InsertionsClient/Api/Props/PropsFileUpdater.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Net.Insertions.Api.Providers
 				if (_propsFiles.TryGetValue(searchDirectory, out List<PropsFile>? closestPropsFiles))
 				{
 					// Found some props in this directory. Lets try to update
-					foreach (var propFile in closestPropsFiles)
+					foreach (PropsFile propFile in closestPropsFiles)
 					{
 						if (propFile.TryUpdateVariable(variableName, newValue, out existingValue))
 						{

--- a/src/InsertionsClient/Api/Props/PropsFileUpdater.cs
+++ b/src/InsertionsClient/Api/Props/PropsFileUpdater.cs
@@ -9,143 +9,143 @@ using System.Linq;
 
 namespace Microsoft.Net.Insertions.Api.Providers
 {
-	/// <summary>
-	/// Used to find given variables in props files under a given directory and updates their values.
-	/// </summary>
-	internal class PropsFileUpdater
-	{
-		/// <summary>
-		/// Props files, keyed by their immediate directories.
-		/// </summary>
-		private readonly Dictionary<string, List<PropsFile>> _propsFiles = new Dictionary<string, List<PropsFile>>();
+    /// <summary>
+    /// Used to find given variables in props files under a given directory and updates their values.
+    /// </summary>
+    internal class PropsFileUpdater
+    {
+        /// <summary>
+        /// Props files, keyed by their immediate directories.
+        /// </summary>
+        private readonly Dictionary<string, List<PropsFile>> _propsFiles = new Dictionary<string, List<PropsFile>>();
 
-		/// <summary>
-		/// Finds the given variables in props files under the given directory and updates their values.
-		/// </summary>
-		/// <param name="variables">The variables to be updated</param>
-		/// <param name="rootSearchDirectory">Which folder should be searched for props files?</param>
-		/// <returns><see cref="UpdateResults"/> object, storing information about the result of the operation.</returns>
-		public PropsUpdateResults UpdatePropsFiles(IEnumerable<PropsFileVariableReference> variables, string rootSearchDirectory)
-		{
-			Load(rootSearchDirectory);
+        /// <summary>
+        /// Finds the given variables in props files under the given directory and updates their values.
+        /// </summary>
+        /// <param name="variables">The variables to be updated</param>
+        /// <param name="rootSearchDirectory">Which folder should be searched for props files?</param>
+        /// <returns><see cref="UpdateResults"/> object, storing information about the result of the operation.</returns>
+        public PropsUpdateResults UpdatePropsFiles(IEnumerable<PropsFileVariableReference> variables, string rootSearchDirectory)
+        {
+            Load(rootSearchDirectory);
 
-			PropsUpdateResults results = new PropsUpdateResults();
+            PropsUpdateResults results = new PropsUpdateResults();
 
-			foreach (PropsFileVariableReference variableReference in variables)
-			{
-				string referencedDirectory = Path.GetDirectoryName(variableReference.ReferencedFilePath) ?? string.Empty;
-				if (!TryUpdateValue(variableReference.Name, variableReference.Value, referencedDirectory, out PropsFile? updatedFile, out string existingValue))
-				{
-					// Variable was not found.
-					results.UnrecognizedVariables.Add(variableReference);
-					results.OutcomeDetails = "Some of the variables were not found in any .props files.";
-					Trace.WriteLine($"Variable \"{variableReference.Name}\" was not found in any of the .props files.");
-					continue;
-				}
+            foreach (PropsFileVariableReference variableReference in variables)
+            {
+                string referencedDirectory = Path.GetDirectoryName(variableReference.ReferencedFilePath) ?? string.Empty;
+                if (!TryUpdateValue(variableReference.Name, variableReference.Value, referencedDirectory, out PropsFile? updatedFile, out string existingValue))
+                {
+                    // Variable was not found.
+                    results.UnrecognizedVariables.Add(variableReference);
+                    results.OutcomeDetails = "Some of the variables were not found in any .props files.";
+                    Trace.WriteLine($"Variable \"{variableReference.Name}\" was not found in any of the .props files.");
+                    continue;
+                }
 
-				if (variableReference.Value == existingValue)
-				{
-					continue;
-				}
+                if (variableReference.Value == existingValue)
+                {
+                    continue;
+                }
 
-				List<PropsFileVariableReference>? modifiedVariables;
-				if (!results.UpdatedVariables.TryGetValue(updatedFile!, out modifiedVariables))
-				{
-					results.UpdatedVariables[updatedFile!] = modifiedVariables = new List<PropsFileVariableReference>();
-				}
+                List<PropsFileVariableReference>? modifiedVariables;
+                if (!results.UpdatedVariables.TryGetValue(updatedFile!, out modifiedVariables))
+                {
+                    results.UpdatedVariables[updatedFile!] = modifiedVariables = new List<PropsFileVariableReference>();
+                }
 
-				modifiedVariables.Add(variableReference);
-			}
+                modifiedVariables.Add(variableReference);
+            }
 
-			foreach (FileSaveResult saveResult in Save())
-			{
-				results.ModifiedFiles.Add(saveResult);
-			}
+            foreach (FileSaveResult saveResult in Save())
+            {
+                results.ModifiedFiles.Add(saveResult);
+            }
 
-			results.Outcome = true;
-			return results;
-		}
+            results.Outcome = true;
+            return results;
+        }
 
-		/// <summary>
-		/// Finds and preprocessed props file under the given directory.
-		/// </summary>
-		/// <param name="rootSearchDirectory">Root directory that contains the props files.
-		/// Specify the most specific directory as root to prevent searching unnecessary folders.</param>
-		private void Load(string rootSearchDirectory)
-		{
-			string[] paths = Directory.GetFiles(rootSearchDirectory, "*.props", SearchOption.AllDirectories);
-			foreach (string propFilePath in paths)
-			{
-				string directory = Path.GetDirectoryName(propFilePath) ?? "";
+        /// <summary>
+        /// Finds and preprocessed props file under the given directory.
+        /// </summary>
+        /// <param name="rootSearchDirectory">Root directory that contains the props files.
+        /// Specify the most specific directory as root to prevent searching unnecessary folders.</param>
+        private void Load(string rootSearchDirectory)
+        {
+            string[] paths = Directory.GetFiles(rootSearchDirectory, "*.props", SearchOption.AllDirectories);
+            foreach (string propFilePath in paths)
+            {
+                string directory = Path.GetDirectoryName(propFilePath) ?? "";
 
-				List<PropsFile>? propsInDirectory;
-				if (!_propsFiles.TryGetValue(directory, out propsInDirectory))
-				{
-					_propsFiles[directory] = propsInDirectory = new List<PropsFile>();
-				}
+                List<PropsFile>? propsInDirectory;
+                if (!_propsFiles.TryGetValue(directory, out propsInDirectory))
+                {
+                    _propsFiles[directory] = propsInDirectory = new List<PropsFile>();
+                }
 
-				propsInDirectory.Add(new PropsFile(propFilePath));
-			}
-		}
+                propsInDirectory.Add(new PropsFile(propFilePath));
+            }
+        }
 
-		/// <summary>
-		/// Save the changes made to props files onto disk.
-		/// </summary>
-		/// <returns>Results of the attempted file operations.</returns>
-		private IEnumerable<FileSaveResult> Save()
-		{
-			foreach (PropsFile file in _propsFiles.SelectMany(filesInFolder => filesInFolder.Value))
-			{
-				FileSaveResult? result = file.Save();
+        /// <summary>
+        /// Save the changes made to props files onto disk.
+        /// </summary>
+        /// <returns>Results of the attempted file operations.</returns>
+        private IEnumerable<FileSaveResult> Save()
+        {
+            foreach (PropsFile file in _propsFiles.SelectMany(filesInFolder => filesInFolder.Value))
+            {
+                FileSaveResult? result = file.Save();
 
-				if (result == null)
-				{
-					// No changes were made to disk
-					continue;
-				}
+                if (result == null)
+                {
+                    // No changes were made to disk
+                    continue;
+                }
 
-				yield return result.Value;
-			}
-		}
+                yield return result.Value;
+            }
+        }
 
-		/// <summary>
-		/// Attempts to find the given variable in props files and update its value.
-		/// </summary>
-		/// <param name="variableName">Name of the variable to search for.</param>
-		/// <param name="newValue">New value to be assigned to the variable</param>
-		/// <param name="scopeDirectory">The folder containing the file that references the given variable.
-		/// Note that a variable can only be referenced if it is defined in the current or in one  of the 
-		/// parent directories.</param>
-		/// <param name="updatedFile">PropsFile that defines the variable.</param>
-		/// <param name="existingValue">Value of the variable before the update, if found.</param>
-		/// <returns>True, if variable was found and updated.
-		/// False, if variable wasn't found or the existing value was the same as the new one.</returns>
-		private bool TryUpdateValue(string variableName, string newValue, string scopeDirectory, out PropsFile? updatedFile, out string existingValue)
-		{
-			string? searchDirectory = scopeDirectory;
-			while (!string.IsNullOrEmpty(searchDirectory))
-			{
-				if (_propsFiles.TryGetValue(searchDirectory, out List<PropsFile>? closestPropsFiles))
-				{
-					// Found some props in this directory. Lets try to update
-					foreach (PropsFile propFile in closestPropsFiles)
-					{
-						if (propFile.TryUpdateVariable(variableName, newValue, out existingValue))
-						{
-							updatedFile = propFile;
-							return true;
-						}
-					}
-				}
+        /// <summary>
+        /// Attempts to find the given variable in props files and update its value.
+        /// </summary>
+        /// <param name="variableName">Name of the variable to search for.</param>
+        /// <param name="newValue">New value to be assigned to the variable</param>
+        /// <param name="scopeDirectory">The folder containing the file that references the given variable.
+        /// Note that a variable can only be referenced if it is defined in the current or in one  of the 
+        /// parent directories.</param>
+        /// <param name="updatedFile">PropsFile that defines the variable.</param>
+        /// <param name="existingValue">Value of the variable before the update, if found.</param>
+        /// <returns>True, if variable was found and updated.
+        /// False, if variable wasn't found or the existing value was the same as the new one.</returns>
+        private bool TryUpdateValue(string variableName, string newValue, string scopeDirectory, out PropsFile? updatedFile, out string existingValue)
+        {
+            string? searchDirectory = scopeDirectory;
+            while (!string.IsNullOrEmpty(searchDirectory))
+            {
+                if (_propsFiles.TryGetValue(searchDirectory, out List<PropsFile>? closestPropsFiles))
+                {
+                    // Found some props in this directory. Lets try to update
+                    foreach (PropsFile propFile in closestPropsFiles)
+                    {
+                        if (propFile.TryUpdateVariable(variableName, newValue, out existingValue))
+                        {
+                            updatedFile = propFile;
+                            return true;
+                        }
+                    }
+                }
 
-				// Variable was not found in any of the props files. Search higher directories
-				searchDirectory = Path.GetDirectoryName(searchDirectory);
-			}
+                // Variable was not found in any of the props files. Search higher directories
+                searchDirectory = Path.GetDirectoryName(searchDirectory);
+            }
 
-			// Variable was not found in any of the props files.
-			updatedFile = null;
-			existingValue = string.Empty;
-			return false;
-		}
-	}
+            // Variable was not found in any of the props files.
+            updatedFile = null;
+            existingValue = string.Empty;
+            return false;
+        }
+    }
 }

--- a/src/InsertionsClient/Api/Props/PropsFileUpdater.cs
+++ b/src/InsertionsClient/Api/Props/PropsFileUpdater.cs
@@ -1,0 +1,151 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Net.Insertions.Models;
+using Microsoft.Net.Insertions.Props.Models;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.Net.Insertions.Api.Providers
+{
+	/// <summary>
+	/// Used to find given variables in props files under a given directory and updates their values.
+	/// </summary>
+	internal class PropsFileUpdater
+	{
+		/// <summary>
+		/// Props files, keyed by their immediate directories.
+		/// </summary>
+		private readonly Dictionary<string, List<PropsFile>> _propsFiles = new Dictionary<string, List<PropsFile>>();
+
+		/// <summary>
+		/// Finds the given variables in props files under the given directory and updates their values.
+		/// </summary>
+		/// <param name="variables">The variables to be updated</param>
+		/// <param name="rootSearchDirectory">Which folder should be searched for props files?</param>
+		/// <returns><see cref="UpdateResults"/> object, storing information about the result of the operation.</returns>
+		public PropsUpdateResults UpdatePropsFiles(IEnumerable<PropsFileVariableReference> variables, string rootSearchDirectory)
+		{
+			Load(rootSearchDirectory);
+
+			PropsUpdateResults results = new PropsUpdateResults();
+
+			foreach (PropsFileVariableReference variableReference in variables)
+			{
+				string referencedDirectory = Path.GetDirectoryName(variableReference.ReferencedFilePath) ?? string.Empty;
+				if (!TryUpdateValue(variableReference.Name, variableReference.Value, referencedDirectory, out PropsFile? updatedFile, out string existingValue))
+				{
+					// Variable was not found.
+					results.UnrecognizedVariables.Add(variableReference);
+					results.OutcomeDetails = "Some of the variables were not found in any .props files.";
+					Trace.WriteLine($"Variable \"{variableReference.Name}\" was not found in any of the .props files.");
+					continue;
+				}
+
+				if (variableReference.Value == existingValue)
+				{
+					continue;
+				}
+
+				List<PropsFileVariableReference>? modifiedVariables;
+				if (!results.UpdatedVariables.TryGetValue(updatedFile!, out modifiedVariables))
+				{
+					results.UpdatedVariables[updatedFile!] = modifiedVariables = new List<PropsFileVariableReference>();
+				}
+
+				modifiedVariables.Add(variableReference);
+			}
+
+			foreach (FileSaveResult saveResult in Save())
+			{
+				results.ModifiedFiles.Add(saveResult);
+			}
+
+			results.Outcome = true;
+			return results;
+		}
+
+		/// <summary>
+		/// Finds and preprocessed props file under the given directory.
+		/// </summary>
+		/// <param name="rootSearchDirectory">Root directory that contains the props files.
+		/// Specify the most specific directory as root to prevent searching unnecessary folders.</param>
+		private void Load(string rootSearchDirectory)
+		{
+			string[] paths = Directory.GetFiles(rootSearchDirectory, "*.props", SearchOption.AllDirectories);
+			foreach (string propFilePath in paths)
+			{
+				string directory = Path.GetDirectoryName(propFilePath) ?? "";
+
+				List<PropsFile>? propsInDirectory;
+				if (!_propsFiles.TryGetValue(directory, out propsInDirectory))
+				{
+					_propsFiles[directory] = propsInDirectory = new List<PropsFile>();
+				}
+
+				propsInDirectory.Add(new PropsFile(propFilePath));
+			}
+		}
+
+		/// <summary>
+		/// Save the changes made to props files onto disk.
+		/// </summary>
+		/// <returns>Results of the attempted file operations.</returns>
+		private IEnumerable<FileSaveResult> Save()
+		{
+			foreach (PropsFile file in _propsFiles.SelectMany(filesInFolder => filesInFolder.Value))
+			{
+				FileSaveResult? result = file.Save();
+
+				if (result == null)
+				{
+					// No changes were made to disk
+					continue;
+				}
+
+				yield return result.Value;
+			}
+		}
+
+		/// <summary>
+		/// Attempts to find the given variable in props files and update its value.
+		/// </summary>
+		/// <param name="variableName">Name of the variable to search for.</param>
+		/// <param name="newValue">New value to be assigned to the variable</param>
+		/// <param name="scopeDirectory">The folder containing the file that references the given variable.
+		/// Note that a variable can only be referenced if it is defined in the current or in one  of the 
+		/// parent directories.</param>
+		/// <param name="updatedFile">PropsFile that defines the variable.</param>
+		/// <param name="existingValue">Value of the variable before the update, if found.</param>
+		/// <returns>True, if variable was found and updated.
+		/// False, if variable wasn't found or the existing value was the same as the new one.</returns>
+		private bool TryUpdateValue(string variableName, string newValue, string scopeDirectory, out PropsFile? updatedFile, out string existingValue)
+		{
+			string? searchDirectory = scopeDirectory;
+			while (!string.IsNullOrEmpty(searchDirectory))
+			{
+				if (_propsFiles.TryGetValue(searchDirectory, out List<PropsFile>? closestPropsFiles))
+				{
+					// Found some props in this directory. Lets try to update
+					foreach (var propFile in closestPropsFiles)
+					{
+						if (propFile.TryUpdateVariable(variableName, newValue, out existingValue))
+						{
+							updatedFile = propFile;
+							return true;
+						}
+					}
+				}
+
+				// Variable was not found in any of the props files. Search higher directories
+				searchDirectory = Path.GetDirectoryName(searchDirectory);
+			}
+
+			// Variable was not found in any of the props files.
+			updatedFile = null;
+			existingValue = string.Empty;
+			return false;
+		}
+	}
+}

--- a/src/InsertionsClient/Api/Props/PropsFileUpdater.cs
+++ b/src/InsertionsClient/Api/Props/PropsFileUpdater.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Net.Insertions.Api.Providers
     /// <summary>
     /// Used to find given variables in props files under a given directory and updates their values.
     /// </summary>
-    internal class PropsFileUpdater
+    internal sealed class PropsFileUpdater
     {
         /// <summary>
         /// Props files, keyed by their immediate directories.
@@ -37,7 +37,7 @@ namespace Microsoft.Net.Insertions.Api.Providers
                 if (!TryUpdateValue(variableReference.Name, variableReference.Value, referencedDirectory, out PropsFile? updatedFile, out string existingValue))
                 {
                     // Variable was not found.
-                    results.UnrecognizedVariables.Add(variableReference);
+                    results._unrecognizedVariables.Add(variableReference);
                     results.OutcomeDetails = "Some of the variables were not found in any .props files.";
                     Trace.WriteLine($"Variable \"{variableReference.Name}\" was not found in any of the .props files.");
                     continue;
@@ -49,9 +49,10 @@ namespace Microsoft.Net.Insertions.Api.Providers
                 }
 
                 List<PropsFileVariableReference>? modifiedVariables;
-                if (!results.UpdatedVariables.TryGetValue(updatedFile!, out modifiedVariables))
+                if (!results._updatedVariables.TryGetValue(updatedFile!, out modifiedVariables))
                 {
-                    results.UpdatedVariables[updatedFile!] = modifiedVariables = new List<PropsFileVariableReference>();
+                    modifiedVariables = new List<PropsFileVariableReference>();
+                    results._updatedVariables[updatedFile!] = modifiedVariables;
                 }
 
                 modifiedVariables.Add(variableReference);
@@ -59,7 +60,7 @@ namespace Microsoft.Net.Insertions.Api.Providers
 
             foreach (FileSaveResult saveResult in Save())
             {
-                results.ModifiedFiles.Add(saveResult);
+                results._modifiedFiles.Add(saveResult);
             }
 
             results.Outcome = true;

--- a/src/InsertionsClient/Api/Props/PropsVariableDeducer.cs
+++ b/src/InsertionsClient/Api/Props/PropsVariableDeducer.cs
@@ -1,0 +1,167 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Net.Insertions.Api.Models;
+using Microsoft.Net.Insertions.Models;
+using Microsoft.Net.Insertions.Props.Models;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Packaging;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+
+namespace Microsoft.Net.Insertions.Api
+{
+	/// <summary>
+	/// Deduces the values of given props file variables by matching:
+	/// <list type="bullet">
+	/// <item> Paths to files extracted from nuget packages into the folders specified in default.config and .packageconfig files </item>
+	/// <item> Paths to files specified in swr files. </item>
+	/// </list>
+	/// </summary>
+	internal class PropsVariableDeducer
+	{
+		/// <summary>
+		/// Nuget feed used to download packages
+		/// </summary>
+		private readonly string _feed;
+
+		/// <summary>
+		/// Credentials for the feed.
+		/// </summary>
+		private readonly PackageSourceCredential _credentials;
+
+		/// <summary>
+		/// Creates an instance of <see cref="PropsVariableDeducer"/>
+		/// </summary>
+		/// <param name="feed">Url to the feed that will be used to download packages</param>
+		/// <param name="accessToken">Token used to access private feed to download packages</param>
+		public PropsVariableDeducer(string feed, string? accessToken)
+		{
+			_feed = feed;
+
+			_credentials = new PackageSourceCredential(feed, accessToken, accessToken, true, null);
+		}
+
+		/// <summary>
+		/// Deduces the value of the variables in swr files
+		/// </summary>
+		/// <param name="defaultConfigUpdater"></param>
+		/// <param name="updatedPackages"></param>
+		/// <param name="swrFiles"></param>
+		/// <returns></returns>
+		public List<PropsFileVariableReference> DeduceVariableValues(DefaultConfigUpdater defaultConfigUpdater, IEnumerable<PackageUpdateResult> updatedPackages, SwrFile[] swrFiles)
+		{
+			ConcurrentBag<PropsFileVariableReference> deducedVariables = new ConcurrentBag<PropsFileVariableReference>();
+
+			TransformManyBlock<PackageUpdateResult, string> nugetDownloadBlock = new TransformManyBlock<PackageUpdateResult, string>(async (packageUpdate) =>
+			{
+				return await GetPackageFileList(defaultConfigUpdater, packageUpdate);
+			});
+
+			ActionBlock<string> filenameMatchBlock = new ActionBlock<string>((filename) =>
+			{
+				foreach (PropsFileVariableReference varReference in MatchFileNames(swrFiles, filename))
+				{
+					deducedVariables.Add(varReference);
+				}
+			});
+
+			nugetDownloadBlock.LinkTo(filenameMatchBlock, new DataflowLinkOptions() { PropagateCompletion = true });
+
+			foreach (var package in updatedPackages)
+			{
+				nugetDownloadBlock.Post(package);
+			}
+
+			nugetDownloadBlock.Complete();
+			filenameMatchBlock.Completion.Wait();
+
+			return deducedVariables.ToList();
+		}
+
+		private async Task<IEnumerable<string>> GetPackageFileList(DefaultConfigUpdater defaultConfigUpdater, PackageUpdateResult packageUpdate)
+		{
+			string? link = defaultConfigUpdater.GetPackageLink(packageUpdate.PackageId);
+
+			if (link == null)
+			{
+				// We don't know where nuget package should be extracted to.
+				return Enumerable.Empty<string>();
+			}
+
+			SourceCacheContext cache = new SourceCacheContext();
+			CancellationTokenSource cancellationToken = new CancellationTokenSource();
+			NuGetVersion packageVersion = new NuGetVersion(packageUpdate.NewVersion);
+
+			// Stream that will receive the package bytes
+			using MemoryStream packageStream = new MemoryStream();
+
+			try
+			{
+				var rep = Repository.Factory.GetCoreV3(_feed, FeedType.HttpV3);
+				rep.PackageSource.Credentials = _credentials;
+				var resource = await rep.GetResourceAsync<FindPackageByIdResource>();
+
+				Trace.WriteLine($"Downloading package {packageUpdate.PackageId}-{packageUpdate.NewVersion} into memory.");
+
+				bool downloadResult = await resource.CopyNupkgToStreamAsync(
+					packageUpdate.PackageId,
+					packageVersion,
+					packageStream,
+					cache,
+					NullLogger.Instance,
+					cancellationToken.Token);
+
+				if (!downloadResult)
+				{
+					Trace.WriteLine($"There is an issue downloading nuget package: {packageUpdate.PackageId}");
+					return Enumerable.Empty<string>();
+				}
+
+				Trace.WriteLine($"Downloading complete for package {packageUpdate.PackageId}.");
+
+				using PackageArchiveReader packageReader = new PackageArchiveReader(packageStream);
+
+				return packageReader.GetFiles().Select(file =>
+				{
+					// Construct path to the file
+					// Link always has backslash. Make sure it is consistent.
+					return link + "\\" + file.Replace('/', '\\');
+				}).ToList();
+			}
+			catch (Exception e)
+			{
+				Trace.WriteLine("There is an issue downloading nuget package: " + e.ToString());
+				return Enumerable.Empty<string>();
+			}
+		}
+
+		private IEnumerable<PropsFileVariableReference> MatchFileNames(SwrFile[] swrFiles, string filename)
+		{
+			foreach (SwrFile swrFile in swrFiles)
+			{
+				foreach (SwrFile.PayloadPath payloadPath in swrFile.PayloadPaths)
+				{
+					Match match = payloadPath.Pattern.Match(filename);
+					if (!match.Success)
+					{
+						continue;
+					}
+
+					yield return new PropsFileVariableReference(payloadPath.VariableName, match.Groups[1].Value, swrFile.Path);
+				}
+			}
+		}
+	}
+}

--- a/src/InsertionsClient/Api/Props/PropsVariableDeducer.cs
+++ b/src/InsertionsClient/Api/Props/PropsVariableDeducer.cs
@@ -22,154 +22,154 @@ using System.Threading.Tasks.Dataflow;
 
 namespace Microsoft.Net.Insertions.Api
 {
-	/// <summary>
-	/// Deduces the values of given props file variables by matching:
-	/// <list type="bullet">
-	/// <item> Paths to files extracted from nuget packages into the folders specified in default.config and .packageconfig files </item>
-	/// <item> Paths to files specified in swr files. </item>
-	/// </list>
-	/// </summary>
-	internal class PropsVariableDeducer
-	{
-		/// <summary>
-		/// Nuget feed used to download packages
-		/// </summary>
-		private readonly string _feed;
+    /// <summary>
+    /// Deduces the values of given props file variables by matching:
+    /// <list type="bullet">
+    /// <item> Paths to files extracted from nuget packages into the folders specified in default.config and .packageconfig files </item>
+    /// <item> Paths to files specified in swr files. </item>
+    /// </list>
+    /// </summary>
+    internal class PropsVariableDeducer
+    {
+        /// <summary>
+        /// Nuget feed used to download packages
+        /// </summary>
+        private readonly string _feed;
 
-		/// <summary>
-		/// Credentials for the feed.
-		/// Null, if no access token was provided.
-		/// </summary>
-		private readonly PackageSourceCredential? _credentials;
+        /// <summary>
+        /// Credentials for the feed.
+        /// Null, if no access token was provided.
+        /// </summary>
+        private readonly PackageSourceCredential? _credentials;
 
-		/// <summary>
-		/// Creates an instance of <see cref="PropsVariableDeducer"/>
-		/// </summary>
-		/// <param name="feed">Url to the feed that will be used to download packages</param>
-		/// <param name="accessToken">Token used to access private feed to download packages</param>
-		public PropsVariableDeducer(string feed, string? accessToken)
-		{
-			_feed = feed;
+        /// <summary>
+        /// Creates an instance of <see cref="PropsVariableDeducer"/>
+        /// </summary>
+        /// <param name="feed">Url to the feed that will be used to download packages</param>
+        /// <param name="accessToken">Token used to access private feed to download packages</param>
+        public PropsVariableDeducer(string feed, string? accessToken)
+        {
+            _feed = feed;
 
-			if(accessToken != null)
-			{
-				_credentials = new PackageSourceCredential(feed, accessToken, accessToken, true, null);
-			}
-		}
+            if (accessToken != null)
+            {
+                _credentials = new PackageSourceCredential(feed, accessToken, accessToken, true, null);
+            }
+        }
 
-		/// <summary>
-		/// Deduces the value of the variables in swr files
-		/// </summary>
-		/// <param name="defaultConfigUpdater"></param>
-		/// <param name="updatedPackages"></param>
-		/// <param name="swrFiles"></param>
-		/// <returns></returns>
-		public List<PropsFileVariableReference> DeduceVariableValues(DefaultConfigUpdater defaultConfigUpdater, IEnumerable<PackageUpdateResult> updatedPackages, SwrFile[] swrFiles)
-		{
-			ConcurrentBag<PropsFileVariableReference> deducedVariables = new ConcurrentBag<PropsFileVariableReference>();
+        /// <summary>
+        /// Deduces the value of the variables in swr files
+        /// </summary>
+        /// <param name="defaultConfigUpdater"></param>
+        /// <param name="updatedPackages"></param>
+        /// <param name="swrFiles"></param>
+        /// <returns></returns>
+        public List<PropsFileVariableReference> DeduceVariableValues(DefaultConfigUpdater defaultConfigUpdater, IEnumerable<PackageUpdateResult> updatedPackages, SwrFile[] swrFiles)
+        {
+            ConcurrentBag<PropsFileVariableReference> deducedVariables = new ConcurrentBag<PropsFileVariableReference>();
 
-			TransformManyBlock<PackageUpdateResult, string> nugetDownloadBlock = new TransformManyBlock<PackageUpdateResult, string>(async (packageUpdate) =>
-			{
-				return await GetPackageFileList(defaultConfigUpdater, packageUpdate);
-			});
+            TransformManyBlock<PackageUpdateResult, string> nugetDownloadBlock = new TransformManyBlock<PackageUpdateResult, string>(async (packageUpdate) =>
+            {
+                return await GetPackageFileList(defaultConfigUpdater, packageUpdate);
+            });
 
-			ActionBlock<string> filenameMatchBlock = new ActionBlock<string>((filename) =>
-			{
-				foreach (PropsFileVariableReference varReference in MatchFileNames(swrFiles, filename))
-				{
-					deducedVariables.Add(varReference);
-				}
-			});
+            ActionBlock<string> filenameMatchBlock = new ActionBlock<string>((filename) =>
+            {
+                foreach (PropsFileVariableReference varReference in MatchFileNames(swrFiles, filename))
+                {
+                    deducedVariables.Add(varReference);
+                }
+            });
 
-			nugetDownloadBlock.LinkTo(filenameMatchBlock, new DataflowLinkOptions() { PropagateCompletion = true });
+            nugetDownloadBlock.LinkTo(filenameMatchBlock, new DataflowLinkOptions() { PropagateCompletion = true });
 
-			foreach (PackageUpdateResult package in updatedPackages)
-			{
-				nugetDownloadBlock.Post(package);
-			}
+            foreach (PackageUpdateResult package in updatedPackages)
+            {
+                nugetDownloadBlock.Post(package);
+            }
 
-			nugetDownloadBlock.Complete();
-			filenameMatchBlock.Completion.Wait();
+            nugetDownloadBlock.Complete();
+            filenameMatchBlock.Completion.Wait();
 
-			return deducedVariables.ToList();
-		}
+            return deducedVariables.ToList();
+        }
 
-		private async Task<IEnumerable<string>> GetPackageFileList(DefaultConfigUpdater defaultConfigUpdater, PackageUpdateResult packageUpdate)
-		{
-			string? link = defaultConfigUpdater.GetPackageLink(packageUpdate.PackageId);
+        private async Task<IEnumerable<string>> GetPackageFileList(DefaultConfigUpdater defaultConfigUpdater, PackageUpdateResult packageUpdate)
+        {
+            string? link = defaultConfigUpdater.GetPackageLink(packageUpdate.PackageId);
 
-			if (link == null)
-			{
-				// We don't know where nuget package should be extracted to.
-				return Enumerable.Empty<string>();
-			}
+            if (link == null)
+            {
+                // We don't know where nuget package should be extracted to.
+                return Enumerable.Empty<string>();
+            }
 
-			SourceCacheContext cache = new SourceCacheContext();
-			CancellationTokenSource cancellationToken = new CancellationTokenSource();
-			NuGetVersion packageVersion = new NuGetVersion(packageUpdate.NewVersion);
+            SourceCacheContext cache = new SourceCacheContext();
+            CancellationTokenSource cancellationToken = new CancellationTokenSource();
+            NuGetVersion packageVersion = new NuGetVersion(packageUpdate.NewVersion);
 
-			// Stream that will receive the package bytes
-			using MemoryStream packageStream = new MemoryStream();
+            // Stream that will receive the package bytes
+            using MemoryStream packageStream = new MemoryStream();
 
-			try
-			{
-				SourceRepository? rep = Repository.Factory.GetCoreV3(_feed, FeedType.HttpV3);
-				if(_credentials != null)
-				{
-					rep.PackageSource.Credentials = _credentials;
-				}
+            try
+            {
+                SourceRepository? rep = Repository.Factory.GetCoreV3(_feed, FeedType.HttpV3);
+                if (_credentials != null)
+                {
+                    rep.PackageSource.Credentials = _credentials;
+                }
 
-				FindPackageByIdResource? resource = await rep.GetResourceAsync<FindPackageByIdResource>();
+                FindPackageByIdResource? resource = await rep.GetResourceAsync<FindPackageByIdResource>();
 
-				Trace.WriteLine($"Downloading package {packageUpdate.PackageId}-{packageUpdate.NewVersion} into memory.");
+                Trace.WriteLine($"Downloading package {packageUpdate.PackageId}-{packageUpdate.NewVersion} into memory.");
 
-				bool downloadResult = await resource.CopyNupkgToStreamAsync(
-					packageUpdate.PackageId,
-					packageVersion,
-					packageStream,
-					cache,
-					NullLogger.Instance,
-					cancellationToken.Token);
+                bool downloadResult = await resource.CopyNupkgToStreamAsync(
+                    packageUpdate.PackageId,
+                    packageVersion,
+                    packageStream,
+                    cache,
+                    NullLogger.Instance,
+                    cancellationToken.Token);
 
-				if (!downloadResult)
-				{
-					Trace.WriteLine($"There is an issue downloading nuget package: {packageUpdate.PackageId}");
-					return Enumerable.Empty<string>();
-				}
+                if (!downloadResult)
+                {
+                    Trace.WriteLine($"There is an issue downloading nuget package: {packageUpdate.PackageId}");
+                    return Enumerable.Empty<string>();
+                }
 
-				Trace.WriteLine($"Downloading complete for package {packageUpdate.PackageId}.");
+                Trace.WriteLine($"Downloading complete for package {packageUpdate.PackageId}.");
 
-				using PackageArchiveReader packageReader = new PackageArchiveReader(packageStream);
+                using PackageArchiveReader packageReader = new PackageArchiveReader(packageStream);
 
-				return packageReader.GetFiles().Select(file =>
-				{
-					// Construct path to the file
-					// Link always has backslash. Make sure it is consistent.
-					return link + "\\" + file.Replace('/', '\\');
-				}).ToList();
-			}
-			catch (Exception e)
-			{
-				Trace.WriteLine("There is an issue downloading nuget package: " + e.ToString());
-				return Enumerable.Empty<string>();
-			}
-		}
+                return packageReader.GetFiles().Select(file =>
+                {
+                    // Construct path to the file
+                    // Link always has backslash. Make sure it is consistent.
+                    return link + "\\" + file.Replace('/', '\\');
+                }).ToList();
+            }
+            catch (Exception e)
+            {
+                Trace.WriteLine("There is an issue downloading nuget package: " + e.ToString());
+                return Enumerable.Empty<string>();
+            }
+        }
 
-		private IEnumerable<PropsFileVariableReference> MatchFileNames(SwrFile[] swrFiles, string filename)
-		{
-			foreach (SwrFile swrFile in swrFiles)
-			{
-				foreach (SwrFile.PayloadPath payloadPath in swrFile.PayloadPaths)
-				{
-					Match match = payloadPath.Pattern.Match(filename);
-					if (!match.Success)
-					{
-						continue;
-					}
+        private IEnumerable<PropsFileVariableReference> MatchFileNames(SwrFile[] swrFiles, string filename)
+        {
+            foreach (SwrFile swrFile in swrFiles)
+            {
+                foreach (SwrFile.PayloadPath payloadPath in swrFile.PayloadPaths)
+                {
+                    Match match = payloadPath.Pattern.Match(filename);
+                    if (!match.Success)
+                    {
+                        continue;
+                    }
 
-					yield return new PropsFileVariableReference(payloadPath.VariableName, match.Groups[1].Value, swrFile.Path);
-				}
-			}
-		}
-	}
+                    yield return new PropsFileVariableReference(payloadPath.VariableName, match.Groups[1].Value, swrFile.Path);
+                }
+            }
+        }
+    }
 }

--- a/src/InsertionsClient/Api/Props/PropsVariableDeducer.cs
+++ b/src/InsertionsClient/Api/Props/PropsVariableDeducer.cs
@@ -38,8 +38,9 @@ namespace Microsoft.Net.Insertions.Api
 
 		/// <summary>
 		/// Credentials for the feed.
+		/// Null, if no access token was provided.
 		/// </summary>
-		private readonly PackageSourceCredential _credentials;
+		private readonly PackageSourceCredential? _credentials;
 
 		/// <summary>
 		/// Creates an instance of <see cref="PropsVariableDeducer"/>
@@ -50,7 +51,10 @@ namespace Microsoft.Net.Insertions.Api
 		{
 			_feed = feed;
 
-			_credentials = new PackageSourceCredential(feed, accessToken, accessToken, true, null);
+			if(accessToken != null)
+			{
+				_credentials = new PackageSourceCredential(feed, accessToken, accessToken, true, null);
+			}
 		}
 
 		/// <summary>
@@ -110,7 +114,11 @@ namespace Microsoft.Net.Insertions.Api
 			try
 			{
 				SourceRepository? rep = Repository.Factory.GetCoreV3(_feed, FeedType.HttpV3);
-				rep.PackageSource.Credentials = _credentials;
+				if(_credentials != null)
+				{
+					rep.PackageSource.Credentials = _credentials;
+				}
+
 				FindPackageByIdResource? resource = await rep.GetResourceAsync<FindPackageByIdResource>();
 
 				Trace.WriteLine($"Downloading package {packageUpdate.PackageId}-{packageUpdate.NewVersion} into memory.");

--- a/src/InsertionsClient/Api/Props/PropsVariableDeducer.cs
+++ b/src/InsertionsClient/Api/Props/PropsVariableDeducer.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.Net.Insertions.Api.Models;
+using Microsoft.Net.Insertions.Api.Props.Models;
 using Microsoft.Net.Insertions.Models;
 using Microsoft.Net.Insertions.Props.Models;
 using NuGet.Common;
@@ -175,7 +175,7 @@ namespace Microsoft.Net.Insertions.Api
         {
             foreach (SwrFile swrFile in swrFiles)
             {
-                foreach (SwrFile.PayloadPath payloadPath in swrFile.PayloadPaths)
+                foreach (PayloadPath payloadPath in swrFile.PayloadPaths)
                 {
                     Match match = payloadPath.Pattern.Match(filename);
                     if (!match.Success)

--- a/src/InsertionsClient/Api/Props/PropsVariableDeducer.cs
+++ b/src/InsertionsClient/Api/Props/PropsVariableDeducer.cs
@@ -161,7 +161,8 @@ namespace Microsoft.Net.Insertions.Api
             }
             catch (Exception e)
             {
-                Trace.WriteLine("There is an issue downloading nuget package: " + e.ToString());
+                Trace.WriteLine($"There is an issue downloading nuget package.");
+                Trace.WriteLine(e.ToString());
                 return Enumerable.Empty<string>();
             }
             finally

--- a/src/InsertionsClient/Api/Props/PropsVariableDeducer.cs
+++ b/src/InsertionsClient/Api/Props/PropsVariableDeducer.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Net.Insertions.Api
 
 			nugetDownloadBlock.LinkTo(filenameMatchBlock, new DataflowLinkOptions() { PropagateCompletion = true });
 
-			foreach (var package in updatedPackages)
+			foreach (PackageUpdateResult package in updatedPackages)
 			{
 				nugetDownloadBlock.Post(package);
 			}
@@ -109,9 +109,9 @@ namespace Microsoft.Net.Insertions.Api
 
 			try
 			{
-				var rep = Repository.Factory.GetCoreV3(_feed, FeedType.HttpV3);
+				SourceRepository? rep = Repository.Factory.GetCoreV3(_feed, FeedType.HttpV3);
 				rep.PackageSource.Credentials = _credentials;
-				var resource = await rep.GetResourceAsync<FindPackageByIdResource>();
+				FindPackageByIdResource? resource = await rep.GetResourceAsync<FindPackageByIdResource>();
 
 				Trace.WriteLine($"Downloading package {packageUpdate.PackageId}-{packageUpdate.NewVersion} into memory.");
 

--- a/src/InsertionsClient/Api/Props/PropsVariableDeducer.cs
+++ b/src/InsertionsClient/Api/Props/PropsVariableDeducer.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Net.Insertions.Api
     /// <item> Paths to files specified in swr files. </item>
     /// </list>
     /// </summary>
-    internal class PropsVariableDeducer
+    internal sealed class PropsVariableDeducer
     {
         /// <summary>
         /// Nuget feed used to download packages
@@ -64,7 +64,8 @@ namespace Microsoft.Net.Insertions.Api
         /// <param name="updatedPackages"></param>
         /// <param name="swrFiles"></param>
         /// <returns></returns>
-        public List<PropsFileVariableReference> DeduceVariableValues(DefaultConfigUpdater defaultConfigUpdater, IEnumerable<PackageUpdateResult> updatedPackages, SwrFile[] swrFiles)
+        public List<PropsFileVariableReference> DeduceVariableValues(DefaultConfigUpdater defaultConfigUpdater, IEnumerable<PackageUpdateResult> updatedPackages,
+            SwrFile[] swrFiles, int maximumWaitSeconds = -1)
         {
             ConcurrentBag<PropsFileVariableReference> deducedVariables = new ConcurrentBag<PropsFileVariableReference>();
 
@@ -89,7 +90,12 @@ namespace Microsoft.Net.Insertions.Api
             }
 
             nugetDownloadBlock.Complete();
-            filenameMatchBlock.Completion.Wait();
+            bool executedToCompletion = filenameMatchBlock.Completion.Wait(-1);
+
+            if(executedToCompletion == false)
+            {
+                Trace.WriteLine("Failed to download and process all the nuget packages in time.");
+            }
 
             return deducedVariables.ToList();
         }

--- a/src/InsertionsClient/Api/Props/SwrFileReader.cs
+++ b/src/InsertionsClient/Api/Props/SwrFileReader.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Net.Insertions.Api
     /// <summary>
     /// Finds and loads .swr files in a given directory.
     /// </summary>
-    internal class SwrFileReader
+    internal sealed class SwrFileReader
     {
         private readonly int _maxConcurrency;
 
@@ -76,7 +76,7 @@ namespace Microsoft.Net.Insertions.Api
                 variableInput = variableInput.Replace("!(bindpath.sources)", "src");
 
                 Match variableMatch = _variablePattern.Match(variableInput);
-                if (variableMatch.Success == false)
+                if (!variableMatch.Success)
                 {
                     // This payload path contains no variables. Skip
                     continue;

--- a/src/InsertionsClient/Api/Props/SwrFileReader.cs
+++ b/src/InsertionsClient/Api/Props/SwrFileReader.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Net.Insertions.Api.Models;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Microsoft.Net.Insertions.Api
+{
+	/// <summary>
+	/// Finds and loads .swr files in a given directory.
+	/// </summary>
+	internal class SwrFileReader
+	{
+		private readonly int _maxConcurrency;
+
+		/// <summary>
+		/// Pattern that finds payload path in swr file content.
+		/// </summary>
+		private Regex _payloadPattern = new Regex(@"\bvs.payload.*source=(.+?)($|\s)");
+		
+		/// <summary>
+		/// Pattern that finds variable name in payload path
+		/// </summary>
+		private Regex _variablePattern = new Regex(@".*\$\((.*)\).*");
+
+		/// <summary>
+		/// Creates an instance of <see cref="SwrFileReader"/>
+		/// </summary>
+		/// <param name="maxConcurrency">Level of concurrency</param>
+		public SwrFileReader(int maxConcurrency)
+		{
+			_maxConcurrency = maxConcurrency;
+		}
+
+		/// <summary>
+		/// Loads all swr files under the given root.
+		/// </summary>
+		/// <param name="rootSearchDirectory">Directory that will be searched for swr files.
+		/// Contained folders will automatically be included in the search.
+		/// Path shouldn't be null, empty or whitespace.</param>
+		/// <returns>A list of <see cref="SwrFile"/>s found under the root.</returns>
+		public SwrFile[] LoadSwrFiles(string rootSearchDirectory)
+		{
+			DirectoryInfo rootDirectory = new DirectoryInfo(rootSearchDirectory);
+			if(!rootDirectory.Exists)
+			{
+				return new SwrFile[0];
+			}
+
+			FileInfo[] files = rootDirectory.GetFiles("*.swr", SearchOption.AllDirectories);
+			SwrFile[] swrFiles = new SwrFile[files.Length];
+
+			ParallelOptions options = new ParallelOptions()
+			{
+				MaxDegreeOfParallelism = _maxConcurrency
+			};
+
+			_ = Parallel.For(0, files.Length, options, async i => swrFiles[i] = await LoadSwrFile(files[i]));
+
+			return swrFiles;
+		}
+
+		private async Task<SwrFile> LoadSwrFile(FileInfo file)
+		{
+			SwrFile swr = new SwrFile(file.FullName);
+
+			string fileContent = await File.ReadAllTextAsync(swr.Path);
+
+			foreach(Group matchedGroup in _payloadPattern.Matches(fileContent).Select(m => m.Groups[1]))
+			{
+				string variableInput = matchedGroup.Value;
+
+				// Replace known variable with actual value
+				variableInput = variableInput.Replace("!(bindpath.sources)", "src");
+
+				Match variableMatch = _variablePattern.Match(variableInput);
+				if(variableMatch.Success == false)
+				{
+					// This payload path contains no variables. Skip
+					continue;
+				}
+
+				Group variableGroup = variableMatch.Groups[1];
+				string variableName = variableGroup.Value;
+				string variableValuePattern = variableInput.Substring(0, variableGroup.Index - 2) +
+					"(.*)" +
+					variableInput.Substring(variableGroup.Index + variableGroup.Length + 1);
+
+				// Backslashes should be considered as literals in regex
+				variableValuePattern= variableValuePattern.Replace("\\", "\\\\");
+
+				swr.PayloadPaths.Add(new SwrFile.PayloadPath(new Regex(variableValuePattern), variableName));
+			}
+
+			return swr;
+		}
+	}
+}

--- a/src/InsertionsClient/Api/Props/SwrFileReader.cs
+++ b/src/InsertionsClient/Api/Props/SwrFileReader.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.Net.Insertions.Api.Models;
+using Microsoft.Net.Insertions.Api.Props.Models;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -91,7 +91,7 @@ namespace Microsoft.Net.Insertions.Api
                 // Backslashes should be considered as literals in regex
                 variableValuePattern = variableValuePattern.Replace("\\", "\\\\");
 
-                swr.PayloadPaths.Add(new SwrFile.PayloadPath(new Regex(variableValuePattern), variableName));
+                swr.PayloadPaths.Add(new PayloadPath(new Regex(variableValuePattern), variableName));
             }
 
             return swr;

--- a/src/InsertionsClient/Api/Props/SwrFileReader.cs
+++ b/src/InsertionsClient/Api/Props/SwrFileReader.cs
@@ -57,16 +57,16 @@ namespace Microsoft.Net.Insertions.Api
 				MaxDegreeOfParallelism = _maxConcurrency
 			};
 
-			_ = Parallel.For(0, files.Length, options, async i => swrFiles[i] = await LoadSwrFile(files[i]));
+			_ = Parallel.For(0, files.Length, options, i => swrFiles[i] = LoadSwrFile(files[i]));
 
 			return swrFiles;
 		}
 
-		private async Task<SwrFile> LoadSwrFile(FileInfo file)
+		private SwrFile LoadSwrFile(FileInfo file)
 		{
 			SwrFile swr = new SwrFile(file.FullName);
 
-			string fileContent = await File.ReadAllTextAsync(swr.Path);
+			string fileContent = File.ReadAllText(swr.Path);
 
 			foreach(Group matchedGroup in _payloadPattern.Matches(fileContent).Select(m => m.Groups[1]))
 			{

--- a/src/InsertionsClient/Api/Providers/InsertionApi.cs
+++ b/src/InsertionsClient/Api/Providers/InsertionApi.cs
@@ -25,13 +25,17 @@ namespace Microsoft.Net.Insertions.Api.Providers
     {
         private readonly MeasurementsSession _metrics;
 
-        private readonly int _maxWaitSeconds = 75, _maxConcurrentWorkers = 15;
+        private readonly int _maxWaitSeconds = 75;
 
+        private readonly int _maxConcurrentWorkers = 15;
 
-        internal InsertionApi(int? maxWaitSeconds = null, int? maxConcurrency = null)
+        private readonly int _maxDownloadSeconds = 240;
+
+        internal InsertionApi(int? maxWaitSeconds = null, int? maxDownloadSeconds = null, int? maxConcurrency = null)
         {
             _metrics = new MeasurementsSession();
             _maxWaitSeconds = Math.Clamp(maxWaitSeconds ?? 120, 60, 120);
+            _maxDownloadSeconds = Math.Clamp(maxDownloadSeconds ?? 240, 60, 900);
             _maxConcurrentWorkers = Math.Clamp(maxConcurrency ?? 20, 1, 20);
         }
 
@@ -95,7 +99,7 @@ namespace Microsoft.Net.Insertions.Api.Providers
                     SwrFile[] swrFiles = swrFileReader.LoadSwrFiles(propsFilesRootDirectory);
 
                     PropsVariableDeducer variableDeducer = new PropsVariableDeducer(InsertionConstants.DefaultNugetFeed, accessToken);
-                    List<PropsFileVariableReference> variables = variableDeducer.DeduceVariableValues(configUpdater, results.UpdatedNuGets, swrFiles);
+                    List<PropsFileVariableReference> variables = variableDeducer.DeduceVariableValues(configUpdater, results.UpdatedNuGets, swrFiles, _maxDownloadSeconds);
 
                     PropsFileUpdater propsFileUpdater = new PropsFileUpdater();
                     results.PropsFileUpdateResults = propsFileUpdater.UpdatePropsFiles(variables, propsFilesRootDirectory);

--- a/src/InsertionsClient/Api/Providers/InsertionApi.cs
+++ b/src/InsertionsClient/Api/Providers/InsertionApi.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.Net.Insertions.Api.Models;
+using Microsoft.Net.Insertions.Api.Props.Models;
 using Microsoft.Net.Insertions.Common.Constants;
 using Microsoft.Net.Insertions.Common.Json;
 using Microsoft.Net.Insertions.Models;

--- a/src/InsertionsClient/Api/Providers/InsertionApi.cs
+++ b/src/InsertionsClient/Api/Providers/InsertionApi.cs
@@ -99,10 +99,17 @@ namespace Microsoft.Net.Insertions.Api.Providers
                     SwrFile[] swrFiles = swrFileReader.LoadSwrFiles(propsFilesRootDirectory);
 
                     PropsVariableDeducer variableDeducer = new PropsVariableDeducer(InsertionConstants.DefaultNugetFeed, accessToken);
-                    List<PropsFileVariableReference> variables = variableDeducer.DeduceVariableValues(configUpdater, results.UpdatedNuGets, swrFiles, _maxDownloadSeconds);
+                    bool deduceOperationResult = variableDeducer.DeduceVariableValues(configUpdater, results.UpdatedNuGets,
+                        swrFiles, out List<PropsFileVariableReference> variables, out string outcomeDetails, _maxDownloadSeconds);
 
                     PropsFileUpdater propsFileUpdater = new PropsFileUpdater();
                     results.PropsFileUpdateResults = propsFileUpdater.UpdatePropsFiles(variables, propsFilesRootDirectory);
+
+                    if(!deduceOperationResult)
+                    {
+                        results.PropsFileUpdateResults.Outcome = false;
+                        results.PropsFileUpdateResults.OutcomeDetails += outcomeDetails;
+                    }
                 }
             }
             catch (Exception e)

--- a/src/InsertionsClient/Api/Providers/InsertionApi.cs
+++ b/src/InsertionsClient/Api/Providers/InsertionApi.cs
@@ -1,7 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using Microsoft.Net.Insertions.Api.Models;
 using Microsoft.Net.Insertions.Common.Constants;
 using Microsoft.Net.Insertions.Common.Json;
+using Microsoft.Net.Insertions.Models;
+using Microsoft.Net.Insertions.Models.Extensions;
+using Microsoft.Net.Insertions.Props.Models;
 using Microsoft.Net.Insertions.Telemetry;
 using System;
 using System.Collections.Concurrent;
@@ -9,25 +13,21 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 using System.Threading;
-using Microsoft.Net.Insertions.Models;
-using Microsoft.Net.Insertions.Models.Extensions;
-using Microsoft.Net.Insertions.Api.Models;
-using Microsoft.Net.Insertions.Props.Models;
+using System.Threading.Tasks;
 
 namespace Microsoft.Net.Insertions.Api.Providers
 {
-	/// <summary>
-	/// <see cref="IInsertionApi"/> provider relying on <see cref="IDefaultConfigApi"/> instances to update NuGet versions.
-	/// </summary>
-	internal sealed class InsertionApi : IInsertionApi
+    /// <summary>
+    /// <see cref="IInsertionApi"/> provider relying on <see cref="IDefaultConfigApi"/> instances to update NuGet versions.
+    /// </summary>
+    internal sealed class InsertionApi : IInsertionApi
     {
         private readonly MeasurementsSession _metrics;
-        
+
         private readonly int _maxWaitSeconds = 75, _maxConcurrentWorkers = 15;
 
-        
+
         internal InsertionApi(int? maxWaitSeconds = null, int? maxConcurrency = null)
         {
             _metrics = new MeasurementsSession();
@@ -40,7 +40,7 @@ namespace Microsoft.Net.Insertions.Api.Providers
 
         public UpdateResults UpdateVersions(string manifestFile, string defaultConfigFile, string ignoredPackagesFile, string? accessToken = null, string? propsFilesRootDirectory = null)
         {
-            return UpdateVersions(manifestFile, defaultConfigFile, LoadPackagesToIgnore(ignoredPackagesFile),accessToken, propsFilesRootDirectory);
+            return UpdateVersions(manifestFile, defaultConfigFile, LoadPackagesToIgnore(ignoredPackagesFile), accessToken, propsFilesRootDirectory);
         }
 
         public UpdateResults UpdateVersions(string manifestFile, string defaultConfigFile, HashSet<string>? packagesToIgnore, string? accessToken = null, string? propsFilesRootDirectory = null)
@@ -79,7 +79,7 @@ namespace Microsoft.Net.Insertions.Api.Providers
                     {
                         Trace.WriteLine("Failed to find an appropriate folder to search for .props files."
                             + "Props file updating will be disabled.");
-                        
+
                         results.PropsFileUpdateResults = new PropsUpdateResults()
                         {
                             Outcome = false,
@@ -95,7 +95,7 @@ namespace Microsoft.Net.Insertions.Api.Providers
                     SwrFile[] swrFiles = swrFileReader.LoadSwrFiles(propsFilesRootDirectory);
 
                     PropsVariableDeducer variableDeducer = new PropsVariableDeducer(InsertionConstants.DefaultNugetFeed, accessToken);
-					List<PropsFileVariableReference> variables = variableDeducer.DeduceVariableValues(configUpdater, results.UpdatedNuGets, swrFiles);
+                    List<PropsFileVariableReference> variables = variableDeducer.DeduceVariableValues(configUpdater, results.UpdatedNuGets, swrFiles);
 
                     PropsFileUpdater propsFileUpdater = new PropsFileUpdater();
                     results.PropsFileUpdateResults = propsFileUpdater.UpdatePropsFiles(variables, propsFilesRootDirectory);
@@ -117,7 +117,7 @@ namespace Microsoft.Net.Insertions.Api.Providers
         private void LogStatistics()
         {
             Trace.WriteLine("Statistics:");
-            foreach(Update update in Enum.GetValues(typeof(Update)).OfType<Update>())
+            foreach (Update update in Enum.GetValues(typeof(Update)).OfType<Update>())
             {
                 Trace.WriteLine($"{update} - {update.GetString()}{Environment.NewLine}{_metrics[update]}");
             }
@@ -145,7 +145,7 @@ namespace Microsoft.Net.Insertions.Api.Providers
             {
                 Manifest? buildManifest = DeserializeManifest(manifestFile);
 
-                if(buildManifest == null)
+                if (buildManifest == null)
                 {
                     assets = new List<Asset>();
                     details = "Failed to read/deserialize manifest file";
@@ -173,7 +173,7 @@ namespace Microsoft.Net.Insertions.Api.Providers
                 {
                     foreach (Asset asset in build.Assets.AsParallel())
                     {
-                        if(string.IsNullOrWhiteSpace(asset.Name))
+                        if (string.IsNullOrWhiteSpace(asset.Name))
                         {
                             Trace.WriteLine($"Manifest file contains an asset with null/empty name: {InsertionConstants.ManifestFile}");
                             continue;
@@ -240,7 +240,7 @@ namespace Microsoft.Net.Insertions.Api.Providers
             HashSet<string> ignoredPackages = new HashSet<string>();
             string[] fileLines = File.ReadAllLines(ignoredPackagesFile);
 
-            foreach(string line in fileLines)
+            foreach (string line in fileLines)
             {
                 ignoredPackages.Add(line);
             }
@@ -273,7 +273,7 @@ namespace Microsoft.Net.Insertions.Api.Providers
 
             _metrics.AddMeasurement(Update.ExactMatch, stopWatch.ElapsedTicks);
 
-            if(oldVersion != asset.Version)
+            if (oldVersion != asset.Version)
             {
                 results.AddPackage(new PackageUpdateResult(packageId, oldVersion, asset.Version!));
                 Trace.WriteLine($"Package {packageId} was updated to version {asset.Version}");
@@ -307,8 +307,8 @@ namespace Microsoft.Net.Insertions.Api.Providers
             string filename = Path.GetFileNameWithoutExtension(assetName);
 
             if (!string.IsNullOrWhiteSpace(version) &&
-                filename.EndsWith(version) && 
-                filename.Length > version.Length && 
+                filename.EndsWith(version) &&
+                filename.Length > version.Length &&
                 filename[filename.Length - 1 - version.Length] == '.')
             {
                 // Package id with a version suffix. Remove version including the dot inbetween.
@@ -318,10 +318,10 @@ namespace Microsoft.Net.Insertions.Api.Providers
 
             int index = 0;
             int versionNumberStart = -1;
-            while(index < filename.Length)
+            while (index < filename.Length)
             {
                 char c = filename[index++];
-                
+
                 if (c > '0' && c <= '9')
                 {
                     continue;
@@ -388,7 +388,7 @@ namespace Microsoft.Net.Insertions.Api.Providers
             // Go down to src/SetupPackages from src folder
             propsFileRootDirectory = Path.Combine(vsRoot.FullName, "src", "SetupPackages");
 
-            if(!Directory.Exists(propsFileRootDirectory))
+            if (!Directory.Exists(propsFileRootDirectory))
             {
                 Trace.WriteLine("Failed to deduce root search directory for .props files: given default.config is not in a VS repo.");
                 propsFileRootDirectory = string.Empty;

--- a/src/InsertionsClient/Api/Providers/InsertionApiFactory.cs
+++ b/src/InsertionsClient/Api/Providers/InsertionApiFactory.cs
@@ -4,9 +4,9 @@ namespace Microsoft.Net.Insertions.Api.Providers
 {
     internal sealed class InsertionApiFactory : IInsertionApiFactory
     {
-        public IInsertionApi Create(int? maxWaitSeconds = null, int? maxConcurrency = null)
+        public IInsertionApi Create(int? maxWaitSeconds = null, int? maxDownloadSeconds = null, int ? maxConcurrency = null)
         {
-            return new InsertionApi(maxWaitSeconds, maxConcurrency);
+            return new InsertionApi(maxWaitSeconds, maxDownloadSeconds, maxConcurrency);
         }
     }
 }

--- a/src/InsertionsClient/Common/Constants/InsertionConstants.cs
+++ b/src/InsertionsClient/Common/Constants/InsertionConstants.cs
@@ -18,5 +18,7 @@ namespace Microsoft.Net.Insertions.Common.Constants
             "VS.Tools.Net.Core.SDK.Resolver",
             "VS.Tools.Net.Core.SDK.x86"
         };
+
+        internal const string DefaultNugetFeed = "https://pkgs.dev.azure.com/devdiv/_packaging/VS-CoreXtFeeds/nuget/v3/index.json";
     }
 }

--- a/src/InsertionsClient/Common/Logging/InsertionsTextWriterTraceListener.cs
+++ b/src/InsertionsClient/Common/Logging/InsertionsTextWriterTraceListener.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Net.Insertions.Common.Logging
     internal sealed class InsertionsTextWriterTraceListener : TextWriterTraceListener
     {
         internal InsertionsTextWriterTraceListener(string fileName, string listenerName)
-            : base(fileName, listenerName) 
+            : base(fileName, listenerName)
         {
 
         }

--- a/src/InsertionsClient/Common/Logging/Utilities.cs
+++ b/src/InsertionsClient/Common/Logging/Utilities.cs
@@ -5,19 +5,19 @@ using System.Text;
 
 namespace Microsoft.Net.Insertions.Common.Logging
 {
-	static class Utilities
-	{
-		private static StringBuilder _logBuilder = new StringBuilder(512);
+    static class Utilities
+    {
+        private static StringBuilder _logBuilder = new StringBuilder(512);
 
-		/// <remarks> This method is not thread safe! </remarks>
-		internal static string MessageToLogString(string message)
-		{
-			_ = _logBuilder.Clear();
-			_ = _logBuilder.Append(DateTime.Now.ToString("dd-M-yyyy hh:mm:ss.ffffff"));
-			_ = _logBuilder.Append("|thread:").Append(Environment.CurrentManagedThreadId);
-			_ = _logBuilder.Append("|").Append(message);
+        /// <remarks> This method is not thread safe! </remarks>
+        internal static string MessageToLogString(string message)
+        {
+            _ = _logBuilder.Clear();
+            _ = _logBuilder.Append(DateTime.Now.ToString("dd-M-yyyy hh:mm:ss.ffffff"));
+            _ = _logBuilder.Append("|thread:").Append(Environment.CurrentManagedThreadId);
+            _ = _logBuilder.Append("|").Append(message);
 
-			return _logBuilder.ToString();
-		}
-	}
+            return _logBuilder.ToString();
+        }
+    }
 }

--- a/src/InsertionsClient/ConsoleApp/Program.cs
+++ b/src/InsertionsClient/ConsoleApp/Program.cs
@@ -152,10 +152,13 @@ namespace Microsoft.Net.Insertions.ConsoleApp
 					}
 				}
 
-				Trace.WriteLine($"{results.PropsFileUpdateResults.UnrecognizedVariables.Count} variables were not found in props files:");
-				foreach (var variable in results.PropsFileUpdateResults.UnrecognizedVariables)
+				if(results.PropsFileUpdateResults.UnrecognizedVariables.Count != 0)
 				{
-					Trace.WriteLine($"        {variable.Name} in {variable.ReferencedFilePath}");
+					Trace.WriteLine($"{results.PropsFileUpdateResults.UnrecognizedVariables.Count} variables were not found in props files:");
+					foreach (var variable in results.PropsFileUpdateResults.UnrecognizedVariables)
+					{
+						Trace.WriteLine($"        {variable.Name} in {variable.ReferencedFilePath}");
+					}
 				}
 			}
 		}

--- a/src/InsertionsClient/ConsoleApp/Program.cs
+++ b/src/InsertionsClient/ConsoleApp/Program.cs
@@ -149,6 +149,13 @@ namespace Microsoft.Net.Insertions.ConsoleApp
 
             if (results.PropsFileUpdateResults != null)
             {
+                Console.ForegroundColor = results.PropsFileUpdateResults.Outcome ? ConsoleColor.Green : ConsoleColor.Red;
+                Console.WriteLine($"Props file updating completed {(results.PropsFileUpdateResults.Outcome ? "successfully" : "in a failure")}.");
+                if(!results.PropsFileUpdateResults.Outcome)
+                {
+                    Console.WriteLine($"Details: {results.PropsFileUpdateResults.OutcomeDetails}.");
+                }
+                Console.ResetColor();
                 Trace.WriteLine($"Updated {results.PropsFileUpdateResults.UpdatedVariables.Count} .props files:");
                 foreach (KeyValuePair<PropsFile, List<PropsFileVariableReference>> propsFile in results.PropsFileUpdateResults.UpdatedVariables.Where(r => r.Value.Count != 0).OrderBy(p => p.Key.Path))
                 {

--- a/src/InsertionsClient/ConsoleApp/Program.cs
+++ b/src/InsertionsClient/ConsoleApp/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.Net.Insertions.Api.Providers;
 using Microsoft.Net.Insertions.Common.Constants;
 using Microsoft.Net.Insertions.Common.Logging;
 using Microsoft.Net.Insertions.Models;
+using Microsoft.Net.Insertions.Props.Models;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -143,19 +144,19 @@ namespace Microsoft.Net.Insertions.ConsoleApp
 			if (results.PropsFileUpdateResults != null)
 			{
 				Trace.WriteLine($"Updated {results.PropsFileUpdateResults.UpdatedVariables.Count} .props files:");
-				foreach (var propsFile in results.PropsFileUpdateResults.UpdatedVariables.Where(r => r.Value.Count != 0).OrderBy(p => p.Key.Path))
+				foreach (KeyValuePair<PropsFile, List<PropsFileVariableReference>> propsFile in results.PropsFileUpdateResults.UpdatedVariables.Where(r => r.Value.Count != 0).OrderBy(p => p.Key.Path))
 				{
 					Trace.WriteLine($"        {propsFile.Key.Path}");
-					foreach (var variableChange in propsFile.Value)
+					foreach (PropsFileVariableReference? variableChange in propsFile.Value)
 					{
 						Trace.WriteLine($"                {variableChange.Name}={variableChange.Value}");
 					}
 				}
 
-				if(results.PropsFileUpdateResults.UnrecognizedVariables.Count != 0)
+				if (results.PropsFileUpdateResults.UnrecognizedVariables.Count != 0)
 				{
 					Trace.WriteLine($"{results.PropsFileUpdateResults.UnrecognizedVariables.Count} variables were not found in props files:");
-					foreach (var variable in results.PropsFileUpdateResults.UnrecognizedVariables)
+					foreach (PropsFileVariableReference? variable in results.PropsFileUpdateResults.UnrecognizedVariables)
 					{
 						Trace.WriteLine($"        {variable.Name} in {variable.ReferencedFilePath}");
 					}

--- a/src/InsertionsClient/ConsoleApp/Program.cs
+++ b/src/InsertionsClient/ConsoleApp/Program.cs
@@ -16,269 +16,269 @@ using System.Text;
 
 namespace Microsoft.Net.Insertions.ConsoleApp
 {
-	internal class Program
-	{
-		private const string SwitchDefaultConfig = "-d:";
+    internal class Program
+    {
+        private const string SwitchDefaultConfig = "-d:";
 
-		private const string SwitchManifest = "-m:";
+        private const string SwitchManifest = "-m:";
 
-		private const string SwitchIgnorePackages = "-i:";
+        private const string SwitchIgnorePackages = "-i:";
 
-		private const string SwitchIgnoreDevUxTeamPackages = "-idut";
+        private const string SwitchIgnoreDevUxTeamPackages = "-idut";
 
-		private const string SwitchPropsFilesRootDir = "-p:";
+        private const string SwitchPropsFilesRootDir = "-p:";
 
-		private const string SwitchFeedAccessToken = "-a:";
+        private const string SwitchFeedAccessToken = "-a:";
 
-		private const string SwitchMaxWaitSeconds = "-w:";
+        private const string SwitchMaxWaitSeconds = "-w:";
 
-		private const string SwitchMaxConcurrency = "-c:";
+        private const string SwitchMaxConcurrency = "-c:";
 
-		private static readonly Lazy<string> HelpParameters = new Lazy<string>(() =>
-		{
-			StringBuilder txt = new StringBuilder();
+        private static readonly Lazy<string> HelpParameters = new Lazy<string>(() =>
+        {
+            StringBuilder txt = new StringBuilder();
 
-			txt.Append($"{SwitchDefaultConfig}<default.config full file path>");
-			txt.Append(" ");
-			txt.Append($"{SwitchManifest}<manifest.json full file path>");
-			txt.Append(" ");
-			txt.Append($"{SwitchIgnorePackages}<ignored packages file path>");
-			txt.Append(" ");
-			txt.Append($"{SwitchPropsFilesRootDir}<root directory that contains props files>");
-			txt.Append(" ");
-			txt.Append($"{SwitchFeedAccessToken}<token to access nuget feed>");
-			txt.Append(" ");
-			txt.Append($"{SwitchMaxWaitSeconds}<maximum seconds to allow job run, as int>");
-			txt.Append(" ");
-			txt.Append($"{SwitchMaxConcurrency}<max concurrent default.config updates, as int>");
+            txt.Append($"{SwitchDefaultConfig}<default.config full file path>");
+            txt.Append(" ");
+            txt.Append($"{SwitchManifest}<manifest.json full file path>");
+            txt.Append(" ");
+            txt.Append($"{SwitchIgnorePackages}<ignored packages file path>");
+            txt.Append(" ");
+            txt.Append($"{SwitchPropsFilesRootDir}<root directory that contains props files>");
+            txt.Append(" ");
+            txt.Append($"{SwitchFeedAccessToken}<token to access nuget feed>");
+            txt.Append(" ");
+            txt.Append($"{SwitchMaxWaitSeconds}<maximum seconds to allow job run, as int>");
+            txt.Append(" ");
+            txt.Append($"{SwitchMaxConcurrency}<max concurrent default.config updates, as int>");
 
-			return txt.ToString();
-		});
+            return txt.ToString();
+        });
 
-		private static readonly Lazy<string> ProgramName = new Lazy<string>(() => Assembly.GetExecutingAssembly().GetName().Name!);
+        private static readonly Lazy<string> ProgramName = new Lazy<string>(() => Assembly.GetExecutingAssembly().GetName().Name!);
 
-		private static string DefaultConfigFile = string.Empty;
+        private static string DefaultConfigFile = string.Empty;
 
-		private static string ManifestFile = string.Empty;
+        private static string ManifestFile = string.Empty;
 
-		private static string IgnoredPackagesFile = string.Empty;
+        private static string IgnoredPackagesFile = string.Empty;
 
-		private static bool IgnoreDevUxTeamPackagesScenario;
+        private static bool IgnoreDevUxTeamPackagesScenario;
 
-		private static string PropsFilesRootDirectory = string.Empty;
+        private static string PropsFilesRootDirectory = string.Empty;
 
-		private static string FeedAccessToken = string.Empty;
+        private static string FeedAccessToken = string.Empty;
 
-		private static int MaxWaitSeconds = 75;
+        private static int MaxWaitSeconds = 75;
 
-		private static int MaxConcurrency = 4;
-
-
-		/// <summary>
-		/// Sets up logging based on the TRACE switch being set.
-		/// </summary>
-		static Program()
-		{
-			string logDirectory = Path.Combine(Directory.GetCurrentDirectory(), "Logs");
-			if (!Directory.Exists(logDirectory))
-			{
-				Directory.CreateDirectory(logDirectory);
-			}
-
-			LogFile = Path.Combine(logDirectory, $"log_{DateTime.Now.Ticks}.txt");
-
-			Trace.AutoFlush = true;
-			_ = Trace.Listeners.Add(new InsertionsTextWriterTraceListener(LogFile, "tracelistener"));
-			_ = Trace.Listeners.Add(new InsertionsConsoleTraceListener());
-		}
+        private static int MaxConcurrency = 4;
 
 
-		private static string LogFile { get; }
+        /// <summary>
+        /// Sets up logging based on the TRACE switch being set.
+        /// </summary>
+        static Program()
+        {
+            string logDirectory = Path.Combine(Directory.GetCurrentDirectory(), "Logs");
+            if (!Directory.Exists(logDirectory))
+            {
+                Directory.CreateDirectory(logDirectory);
+            }
 
-		[STAThread]
-		private static void Main(string[] args)
-		{
-			ShowStartOrEndMessage($"Running {ProgramName.Value}");
+            LogFile = Path.Combine(logDirectory, $"log_{DateTime.Now.Ticks}.txt");
 
-			ProcessCmdArguments(args);
+            Trace.AutoFlush = true;
+            _ = Trace.Listeners.Add(new InsertionsTextWriterTraceListener(LogFile, "tracelistener"));
+            _ = Trace.Listeners.Add(new InsertionsConsoleTraceListener());
+        }
 
-			IInsertionApiFactory apiFactory = new InsertionApiFactory();
-			IInsertionApi api = apiFactory.Create(MaxWaitSeconds, MaxConcurrency);
 
-			UpdateResults results;
-			if (!string.IsNullOrWhiteSpace(IgnoredPackagesFile))
-			{
-				results = api.UpdateVersions(ManifestFile, DefaultConfigFile, IgnoredPackagesFile, FeedAccessToken, PropsFilesRootDirectory);
-			}
-			else if (IgnoreDevUxTeamPackagesScenario)
-			{
-				results = api.UpdateVersions(ManifestFile, DefaultConfigFile, InsertionConstants.DefaultDevUxTeamPackages, FeedAccessToken, PropsFilesRootDirectory);
-			}
-			else
-			{
-				results = api.UpdateVersions(ManifestFile, DefaultConfigFile, (HashSet<string>?)null, FeedAccessToken, PropsFilesRootDirectory);
-			}
+        private static string LogFile { get; }
 
-			ShowResults(results);
+        [STAThread]
+        private static void Main(string[] args)
+        {
+            ShowStartOrEndMessage($"Running {ProgramName.Value}");
 
-			Trace.WriteLine($"Log: {LogFile}{Environment.NewLine}");
-		}
+            ProcessCmdArguments(args);
 
-		private static void ShowResults(UpdateResults results)
-		{
-			Console.ForegroundColor = results.Outcome ? ConsoleColor.Green : ConsoleColor.Red;
-			Console.WriteLine($"Completed {(results.Outcome ? "successfully" : "in a failure")}.");
-			if (!results.Outcome)
-			{
-				Console.WriteLine($"Details: {results.OutcomeDetails}.");
-			}
-			Console.ResetColor();
-			Trace.WriteLine($"Duration: {results.DurationMilliseconds:N2}-ms.");
-			Trace.WriteLine($"Successful updates: {results.UpdatedNuGets.Count():N0}.");
-			Trace.WriteLine("Updated default.config NuGet package versions...");
-			foreach (PackageUpdateResult updatedNuget in results.UpdatedNuGets.OrderBy(r => r.PackageId))
-			{
-				Trace.WriteLine($"           {updatedNuget.PackageId}: {updatedNuget.NewVersion}");
-			}
+            IInsertionApiFactory apiFactory = new InsertionApiFactory();
+            IInsertionApi api = apiFactory.Create(MaxWaitSeconds, MaxConcurrency);
 
-			if (results.PropsFileUpdateResults != null)
-			{
-				Trace.WriteLine($"Updated {results.PropsFileUpdateResults.UpdatedVariables.Count} .props files:");
-				foreach (KeyValuePair<PropsFile, List<PropsFileVariableReference>> propsFile in results.PropsFileUpdateResults.UpdatedVariables.Where(r => r.Value.Count != 0).OrderBy(p => p.Key.Path))
-				{
-					Trace.WriteLine($"        {propsFile.Key.Path}");
-					foreach (PropsFileVariableReference? variableChange in propsFile.Value)
-					{
-						Trace.WriteLine($"                {variableChange.Name}={variableChange.Value}");
-					}
-				}
+            UpdateResults results;
+            if (!string.IsNullOrWhiteSpace(IgnoredPackagesFile))
+            {
+                results = api.UpdateVersions(ManifestFile, DefaultConfigFile, IgnoredPackagesFile, FeedAccessToken, PropsFilesRootDirectory);
+            }
+            else if (IgnoreDevUxTeamPackagesScenario)
+            {
+                results = api.UpdateVersions(ManifestFile, DefaultConfigFile, InsertionConstants.DefaultDevUxTeamPackages, FeedAccessToken, PropsFilesRootDirectory);
+            }
+            else
+            {
+                results = api.UpdateVersions(ManifestFile, DefaultConfigFile, (HashSet<string>?)null, FeedAccessToken, PropsFilesRootDirectory);
+            }
 
-				if (results.PropsFileUpdateResults.UnrecognizedVariables.Count != 0)
-				{
-					Trace.WriteLine($"{results.PropsFileUpdateResults.UnrecognizedVariables.Count} variables were not found in props files:");
-					foreach (PropsFileVariableReference? variable in results.PropsFileUpdateResults.UnrecognizedVariables)
-					{
-						Trace.WriteLine($"        {variable.Name} in {variable.ReferencedFilePath}");
-					}
-				}
-			}
-		}
+            ShowResults(results);
 
-		private static void ShowStartOrEndMessage(string message)
-		{
-			Console.ForegroundColor = ConsoleColor.Green;
-			Console.WriteLine(message);
-			Console.ResetColor();
-		}
+            Trace.WriteLine($"Log: {LogFile}{Environment.NewLine}");
+        }
 
-		private static void ShowHelp()
-		{
-			Console.WriteLine($"{Environment.NewLine}");
-			Console.WriteLine($"{ProgramName.Value} updates versions of NuGet packages in {InsertionConstants.DefaultConfigFile} with the corresponding values from {InsertionConstants.ManifestFile}{Environment.NewLine}");
+        private static void ShowResults(UpdateResults results)
+        {
+            Console.ForegroundColor = results.Outcome ? ConsoleColor.Green : ConsoleColor.Red;
+            Console.WriteLine($"Completed {(results.Outcome ? "successfully" : "in a failure")}.");
+            if (!results.Outcome)
+            {
+                Console.WriteLine($"Details: {results.OutcomeDetails}.");
+            }
+            Console.ResetColor();
+            Trace.WriteLine($"Duration: {results.DurationMilliseconds:N2}-ms.");
+            Trace.WriteLine($"Successful updates: {results.UpdatedNuGets.Count():N0}.");
+            Trace.WriteLine("Updated default.config NuGet package versions...");
+            foreach (PackageUpdateResult updatedNuget in results.UpdatedNuGets.OrderBy(r => r.PackageId))
+            {
+                Trace.WriteLine($"           {updatedNuget.PackageId}: {updatedNuget.NewVersion}");
+            }
 
-			Console.WriteLine($"Usage:");
-			Console.WriteLine($">{ProgramName.Value}.exe {HelpParameters.Value}");
+            if (results.PropsFileUpdateResults != null)
+            {
+                Trace.WriteLine($"Updated {results.PropsFileUpdateResults.UpdatedVariables.Count} .props files:");
+                foreach (KeyValuePair<PropsFile, List<PropsFileVariableReference>> propsFile in results.PropsFileUpdateResults.UpdatedVariables.Where(r => r.Value.Count != 0).OrderBy(p => p.Key.Path))
+                {
+                    Trace.WriteLine($"        {propsFile.Key.Path}");
+                    foreach (PropsFileVariableReference? variableChange in propsFile.Value)
+                    {
+                        Trace.WriteLine($"                {variableChange.Name}={variableChange.Value}");
+                    }
+                }
 
-			Console.WriteLine($"{Environment.NewLine}Options:");
-			Console.WriteLine($"{SwitchDefaultConfig}   full path on disk to default.config to update");
-			Console.WriteLine($"{SwitchManifest}   full path on disk to manifest.json");
-			Console.WriteLine($"{SwitchIgnorePackages}   full path on disk to ignored packages file. Each line should have a package id [optional]");
-			Console.WriteLine($"{SwitchPropsFilesRootDir}   directory to search for and update .props files [optional]");
-			Console.WriteLine($"{FeedAccessToken}   token to access nuget feed. Necessary when updating props files [optional]");
-			Console.WriteLine($"{SwitchMaxWaitSeconds}   maximum allowed duration in seconds [optional]");
-			Console.WriteLine($"{SwitchMaxConcurrency}   maximum concurrency of default.config version updates [optional]{Environment.NewLine}");
+                if (results.PropsFileUpdateResults.UnrecognizedVariables.Count != 0)
+                {
+                    Trace.WriteLine($"{results.PropsFileUpdateResults.UnrecognizedVariables.Count} variables were not found in props files:");
+                    foreach (PropsFileVariableReference? variable in results.PropsFileUpdateResults.UnrecognizedVariables)
+                    {
+                        Trace.WriteLine($"        {variable.Name} in {variable.ReferencedFilePath}");
+                    }
+                }
+            }
+        }
 
-			Console.ForegroundColor = ConsoleColor.Green;
-			Console.WriteLine("Example...");
-			Console.WriteLine($">{ProgramName.Value} {SwitchDefaultConfig}c:\\default.config {SwitchManifest}c:\\manifest.json");
-			Console.ResetColor();
-		}
+        private static void ShowStartOrEndMessage(string message)
+        {
+            Console.ForegroundColor = ConsoleColor.Green;
+            Console.WriteLine(message);
+            Console.ResetColor();
+        }
 
-		private static void ShowErrorHelpAndExit(string reason)
-		{
-			Console.ForegroundColor = ConsoleColor.Red;
-			Console.WriteLine($"Exiting due to incorrect input.  Reason: {reason}");
-			Console.ResetColor();
-			ShowHelp();
-			Environment.Exit(1);
-		}
+        private static void ShowHelp()
+        {
+            Console.WriteLine($"{Environment.NewLine}");
+            Console.WriteLine($"{ProgramName.Value} updates versions of NuGet packages in {InsertionConstants.DefaultConfigFile} with the corresponding values from {InsertionConstants.ManifestFile}{Environment.NewLine}");
 
-		private static void ProcessCmdArguments(string[] args)
-		{
-			Console.ForegroundColor = ConsoleColor.DarkYellow;
-			Console.WriteLine("Processing CMD line parameters");
-			Console.ResetColor();
+            Console.WriteLine($"Usage:");
+            Console.WriteLine($">{ProgramName.Value}.exe {HelpParameters.Value}");
 
-			if (args == null || args.Length < 2)
-			{
-				ShowErrorHelpAndExit("incorrect # of parameters specified");
-			}
+            Console.WriteLine($"{Environment.NewLine}Options:");
+            Console.WriteLine($"{SwitchDefaultConfig}   full path on disk to default.config to update");
+            Console.WriteLine($"{SwitchManifest}   full path on disk to manifest.json");
+            Console.WriteLine($"{SwitchIgnorePackages}   full path on disk to ignored packages file. Each line should have a package id [optional]");
+            Console.WriteLine($"{SwitchPropsFilesRootDir}   directory to search for and update .props files [optional]");
+            Console.WriteLine($"{FeedAccessToken}   token to access nuget feed. Necessary when updating props files [optional]");
+            Console.WriteLine($"{SwitchMaxWaitSeconds}   maximum allowed duration in seconds [optional]");
+            Console.WriteLine($"{SwitchMaxConcurrency}   maximum concurrency of default.config version updates [optional]{Environment.NewLine}");
 
-			foreach (string arg in args!)
-			{
-				if (arg.StartsWith(SwitchDefaultConfig))
-				{
-					ProcessArgument(arg, SwitchDefaultConfig, $"Specified {InsertionConstants.DefaultConfigFile}:", ref DefaultConfigFile);
-				}
-				else if (arg.StartsWith(SwitchManifest))
-				{
-					ProcessArgument(arg, SwitchManifest, $"Specified {InsertionConstants.ManifestFile}:", ref ManifestFile);
-				}
-				else if (arg.StartsWith(SwitchIgnorePackages))
-				{
-					ProcessArgument(arg, SwitchIgnorePackages, $"Specified ignored packages file:", ref IgnoredPackagesFile);
-				}
-				else if (arg.StartsWith(SwitchPropsFilesRootDir))
-				{
-					ProcessArgument(arg, SwitchPropsFilesRootDir, $"Specified root directory for props files:", ref PropsFilesRootDirectory);
-				}
-				else if (arg.StartsWith(SwitchFeedAccessToken))
-				{
-					FeedAccessToken = arg.Replace(SwitchFeedAccessToken, string.Empty);
-					Trace.WriteLine($"CMD line param. An access token was specified.");
-				}
-				else if (arg.StartsWith(SwitchMaxWaitSeconds))
-				{
-					ProcessArgumentInt(arg, SwitchMaxWaitSeconds, $"Specified \"max wait seconds\":", ref MaxWaitSeconds);
-				}
-				else if (arg.StartsWith(SwitchMaxConcurrency))
-				{
-					ProcessArgumentInt(arg, SwitchMaxConcurrency, $"Specified \"max concurrency\":", ref MaxConcurrency);
-				}
-				else if (arg.StartsWith(SwitchIgnoreDevUxTeamPackages))
-				{
-					IgnoreDevUxTeamPackagesScenario = true;
-				}
-			}
+            Console.ForegroundColor = ConsoleColor.Green;
+            Console.WriteLine("Example...");
+            Console.WriteLine($">{ProgramName.Value} {SwitchDefaultConfig}c:\\default.config {SwitchManifest}c:\\manifest.json");
+            Console.ResetColor();
+        }
 
-			if (string.IsNullOrWhiteSpace(DefaultConfigFile))
-			{
-				ShowErrorHelpAndExit($"{InsertionConstants.DefaultConfigFile} path not set.");
-			}
-			if (string.IsNullOrWhiteSpace(ManifestFile))
-			{
-				ShowErrorHelpAndExit($"{InsertionConstants.ManifestFile} path not set.");
-			}
-		}
+        private static void ShowErrorHelpAndExit(string reason)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.WriteLine($"Exiting due to incorrect input.  Reason: {reason}");
+            Console.ResetColor();
+            ShowHelp();
+            Environment.Exit(1);
+        }
 
-		private static void ProcessArgument(string argument, string appSwitch, string cmdLineMessage, ref string target)
-		{
-			target = argument.Replace(appSwitch, string.Empty);
-			Trace.WriteLine($"CMD line param. {cmdLineMessage} {target}");
-		}
+        private static void ProcessCmdArguments(string[] args)
+        {
+            Console.ForegroundColor = ConsoleColor.DarkYellow;
+            Console.WriteLine("Processing CMD line parameters");
+            Console.ResetColor();
 
-		private static void ProcessArgumentInt(string argument, string appSwitch, string cmdLineMessage, ref int target)
-		{
-			string trimmedArg = argument.Replace(appSwitch, string.Empty);
-			if (int.TryParse(trimmedArg, out target))
-			{
-				Trace.WriteLine($"CMD line param. {cmdLineMessage} {target}");
-			}
-			else
-			{
-				target = -1;
-				Trace.WriteLine("Specified value is not an integer. Default value will be used.");
-			}
-		}
-	}
+            if (args == null || args.Length < 2)
+            {
+                ShowErrorHelpAndExit("incorrect # of parameters specified");
+            }
+
+            foreach (string arg in args!)
+            {
+                if (arg.StartsWith(SwitchDefaultConfig))
+                {
+                    ProcessArgument(arg, SwitchDefaultConfig, $"Specified {InsertionConstants.DefaultConfigFile}:", ref DefaultConfigFile);
+                }
+                else if (arg.StartsWith(SwitchManifest))
+                {
+                    ProcessArgument(arg, SwitchManifest, $"Specified {InsertionConstants.ManifestFile}:", ref ManifestFile);
+                }
+                else if (arg.StartsWith(SwitchIgnorePackages))
+                {
+                    ProcessArgument(arg, SwitchIgnorePackages, $"Specified ignored packages file:", ref IgnoredPackagesFile);
+                }
+                else if (arg.StartsWith(SwitchPropsFilesRootDir))
+                {
+                    ProcessArgument(arg, SwitchPropsFilesRootDir, $"Specified root directory for props files:", ref PropsFilesRootDirectory);
+                }
+                else if (arg.StartsWith(SwitchFeedAccessToken))
+                {
+                    FeedAccessToken = arg.Replace(SwitchFeedAccessToken, string.Empty);
+                    Trace.WriteLine($"CMD line param. An access token was specified.");
+                }
+                else if (arg.StartsWith(SwitchMaxWaitSeconds))
+                {
+                    ProcessArgumentInt(arg, SwitchMaxWaitSeconds, $"Specified \"max wait seconds\":", ref MaxWaitSeconds);
+                }
+                else if (arg.StartsWith(SwitchMaxConcurrency))
+                {
+                    ProcessArgumentInt(arg, SwitchMaxConcurrency, $"Specified \"max concurrency\":", ref MaxConcurrency);
+                }
+                else if (arg.StartsWith(SwitchIgnoreDevUxTeamPackages))
+                {
+                    IgnoreDevUxTeamPackagesScenario = true;
+                }
+            }
+
+            if (string.IsNullOrWhiteSpace(DefaultConfigFile))
+            {
+                ShowErrorHelpAndExit($"{InsertionConstants.DefaultConfigFile} path not set.");
+            }
+            if (string.IsNullOrWhiteSpace(ManifestFile))
+            {
+                ShowErrorHelpAndExit($"{InsertionConstants.ManifestFile} path not set.");
+            }
+        }
+
+        private static void ProcessArgument(string argument, string appSwitch, string cmdLineMessage, ref string target)
+        {
+            target = argument.Replace(appSwitch, string.Empty);
+            Trace.WriteLine($"CMD line param. {cmdLineMessage} {target}");
+        }
+
+        private static void ProcessArgumentInt(string argument, string appSwitch, string cmdLineMessage, ref int target)
+        {
+            string trimmedArg = argument.Replace(appSwitch, string.Empty);
+            if (int.TryParse(trimmedArg, out target))
+            {
+                Trace.WriteLine($"CMD line param. {cmdLineMessage} {target}");
+            }
+            else
+            {
+                target = -1;
+                Trace.WriteLine("Specified value is not an integer. Default value will be used.");
+            }
+        }
+    }
 }

--- a/src/InsertionsClient/ConsoleApp/Program.cs
+++ b/src/InsertionsClient/ConsoleApp/Program.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using Microsoft.Net.Insertions.Api;
-using Microsoft.Net.Insertions.Models;
 using Microsoft.Net.Insertions.Api.Providers;
 using Microsoft.Net.Insertions.Common.Constants;
 using Microsoft.Net.Insertions.Common.Logging;
+using Microsoft.Net.Insertions.Models;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -14,224 +15,266 @@ using System.Text;
 
 namespace Microsoft.Net.Insertions.ConsoleApp
 {
-    internal class Program
-    {
-        private const string SwitchDefaultConfig = "-d:";
+	internal class Program
+	{
+		private const string SwitchDefaultConfig = "-d:";
 
-        private const string SwitchManifest = "-m:";
+		private const string SwitchManifest = "-m:";
 
-        private const string SwitchIgnorePackages = "-i:";
+		private const string SwitchIgnorePackages = "-i:";
 
-        private const string SwitchIgnoreDevUxTeamPackages = "-idut";
+		private const string SwitchIgnoreDevUxTeamPackages = "-idut";
 
-        private const string SwitchMaxWaitSeconds = "-w:";
+		private const string SwitchPropsFilesRootDir = "-p:";
 
-        private const string SwitchMaxConcurrency = "-c:";
+		private const string SwitchFeedAccessToken = "-a:";
 
-        private static readonly Lazy<string> HelpParameters = new Lazy<string>(() =>
-        {
-            StringBuilder txt = new StringBuilder();
+		private const string SwitchMaxWaitSeconds = "-w:";
 
-            txt.Append($"{SwitchDefaultConfig}<default.config full file path>");
-            txt.Append(" ");
-            txt.Append($"{SwitchManifest}<manifest.json full file path>");
-            txt.Append(" ");
-            txt.Append($"{SwitchIgnorePackages}<ignored packages file path>");
-            txt.Append(" ");
-            txt.Append($"{SwitchMaxWaitSeconds}<maximum seconds to allow job run, as int>");
-            txt.Append(" ");
-            txt.Append($"{SwitchMaxConcurrency}<max concurrent default.config updates, as int>");
+		private const string SwitchMaxConcurrency = "-c:";
 
-            return txt.ToString();
-        });
+		private static readonly Lazy<string> HelpParameters = new Lazy<string>(() =>
+		{
+			StringBuilder txt = new StringBuilder();
 
-        private static readonly Lazy<string> ProgramName = new Lazy<string>(() => Assembly.GetExecutingAssembly().GetName().Name!);
+			txt.Append($"{SwitchDefaultConfig}<default.config full file path>");
+			txt.Append(" ");
+			txt.Append($"{SwitchManifest}<manifest.json full file path>");
+			txt.Append(" ");
+			txt.Append($"{SwitchIgnorePackages}<ignored packages file path>");
+			txt.Append(" ");
+			txt.Append($"{SwitchPropsFilesRootDir}<root directory that contains props files>");
+			txt.Append(" ");
+			txt.Append($"{SwitchFeedAccessToken}<token to access nuget feed>");
+			txt.Append(" ");
+			txt.Append($"{SwitchMaxWaitSeconds}<maximum seconds to allow job run, as int>");
+			txt.Append(" ");
+			txt.Append($"{SwitchMaxConcurrency}<max concurrent default.config updates, as int>");
 
-        private static string DefaultConfigFile = string.Empty;
+			return txt.ToString();
+		});
 
-        private static string ManifestFile = string.Empty;
+		private static readonly Lazy<string> ProgramName = new Lazy<string>(() => Assembly.GetExecutingAssembly().GetName().Name!);
 
-        private static string IgnoredPackagesFile = string.Empty;
+		private static string DefaultConfigFile = string.Empty;
 
-        private static bool IgnoreDevUxTeamPackagesScenario;
+		private static string ManifestFile = string.Empty;
 
-        private static int MaxWaitSeconds = 75;
+		private static string IgnoredPackagesFile = string.Empty;
 
-        private static int MaxConcurrency = 4;
+		private static bool IgnoreDevUxTeamPackagesScenario;
 
+		private static string PropsFilesRootDirectory = string.Empty;
 
-        /// <summary>
-        /// Sets up logging based on the TRACE switch being set.
-        /// </summary>
-        static Program()
-        {
-            string logDirectory = Path.Combine(Directory.GetCurrentDirectory(), "Logs");
-            if (!Directory.Exists(logDirectory))
-            {
-                Directory.CreateDirectory(logDirectory);
-            }
+		private static string FeedAccessToken = string.Empty;
 
-            LogFile = Path.Combine(logDirectory, $"log_{DateTime.Now.Ticks}.txt");
+		private static int MaxWaitSeconds = 75;
 
-            Trace.AutoFlush = true;
-            _ = Trace.Listeners.Add(new InsertionsTextWriterTraceListener(LogFile, "tracelistener"));
-            _ = Trace.Listeners.Add(new InsertionsConsoleTraceListener());
-        }
+		private static int MaxConcurrency = 4;
 
 
-        private static string LogFile { get; }
+		/// <summary>
+		/// Sets up logging based on the TRACE switch being set.
+		/// </summary>
+		static Program()
+		{
+			string logDirectory = Path.Combine(Directory.GetCurrentDirectory(), "Logs");
+			if (!Directory.Exists(logDirectory))
+			{
+				Directory.CreateDirectory(logDirectory);
+			}
 
-        [STAThread]
-        private static void Main(string[] args)
-        {
-            ShowStartOrEndMessage($"Running {ProgramName.Value}");
+			LogFile = Path.Combine(logDirectory, $"log_{DateTime.Now.Ticks}.txt");
 
-            ProcessCmdArguments(args);
+			Trace.AutoFlush = true;
+			_ = Trace.Listeners.Add(new InsertionsTextWriterTraceListener(LogFile, "tracelistener"));
+			_ = Trace.Listeners.Add(new InsertionsConsoleTraceListener());
+		}
 
-            IInsertionApiFactory apiFactory = new InsertionApiFactory();
-            IInsertionApi api = apiFactory.Create(MaxWaitSeconds, MaxConcurrency);
 
-            UpdateResults results;
-            if (!string.IsNullOrWhiteSpace(IgnoredPackagesFile))
-            {
-                results = api.UpdateVersions(ManifestFile, DefaultConfigFile, IgnoredPackagesFile);
-            }
-            else if (IgnoreDevUxTeamPackagesScenario)
-            {
-                results = api.UpdateVersions(ManifestFile, DefaultConfigFile, InsertionConstants.DefaultDevUxTeamPackages);
-            }
-            else
-            {
-                results = api.UpdateVersions(ManifestFile, DefaultConfigFile);
-            }
+		private static string LogFile { get; }
 
-            ShowResults(results);
+		[STAThread]
+		private static void Main(string[] args)
+		{
+			ShowStartOrEndMessage($"Running {ProgramName.Value}");
 
-            Trace.WriteLine($"Log: {LogFile}{Environment.NewLine}");
-        }
+			ProcessCmdArguments(args);
 
-        private static void ShowResults(UpdateResults results)
-        {
-            Console.ForegroundColor = results.Outcome ? ConsoleColor.Green : ConsoleColor.Red;
-            Console.WriteLine($"Completed {(results.Outcome ? "successfully" : "in a failure")}.");
-            if (!results.Outcome)
-            {
-                Console.WriteLine($"Details: {results.OutcomeDetails}.");
-            }
-            Console.ResetColor();
-            Trace.WriteLine($"Duration: {results.DurationMilliseconds:N2}-ms.");
-            Trace.WriteLine($"Successful updates: {results.UpdatedNuGets.Count():N0}.");
-            Trace.WriteLine("Updated default.config NuGet package versions...");
-            foreach (PackageUpdateResult updatedNuget in results.UpdatedNuGets.OrderBy(r => r.PackageId))
-            {
-                Trace.WriteLine($"           {updatedNuget.PackageId}: {updatedNuget.NewVersion}");
-            }
-        }
+			IInsertionApiFactory apiFactory = new InsertionApiFactory();
+			IInsertionApi api = apiFactory.Create(MaxWaitSeconds, MaxConcurrency);
 
-        private static void ShowStartOrEndMessage(string message)
-        {
-            Console.ForegroundColor = ConsoleColor.Green;
-            Console.WriteLine(message);
-            Console.ResetColor();
-        }
+			UpdateResults results;
+			if (!string.IsNullOrWhiteSpace(IgnoredPackagesFile))
+			{
+				results = api.UpdateVersions(ManifestFile, DefaultConfigFile, IgnoredPackagesFile, FeedAccessToken, PropsFilesRootDirectory);
+			}
+			else if (IgnoreDevUxTeamPackagesScenario)
+			{
+				results = api.UpdateVersions(ManifestFile, DefaultConfigFile, InsertionConstants.DefaultDevUxTeamPackages, FeedAccessToken, PropsFilesRootDirectory);
+			}
+			else
+			{
+				results = api.UpdateVersions(ManifestFile, DefaultConfigFile, (HashSet<string>?)null, FeedAccessToken, PropsFilesRootDirectory);
+			}
 
-        private static void ShowHelp()
-        {
-            Console.WriteLine($"{Environment.NewLine}");
-            Console.WriteLine($"{ProgramName.Value} updates versions of NuGet packages in {InsertionConstants.DefaultConfigFile} with the corresponding values from {InsertionConstants.ManifestFile}{Environment.NewLine}");
+			ShowResults(results);
 
-            Console.WriteLine($"Usage:");
-            Console.WriteLine($">{ProgramName.Value}.exe {HelpParameters.Value}");
+			Trace.WriteLine($"Log: {LogFile}{Environment.NewLine}");
+		}
 
-            Console.WriteLine($"{Environment.NewLine}Options:");
-            Console.WriteLine($"{SwitchDefaultConfig}   full path on disk to default.config to update");
-            Console.WriteLine($"{SwitchManifest}   full path on disk to manifest.json");
-            Console.WriteLine($"{SwitchIgnorePackages}   full path on disk to ignored packages file. Each line should have a package id [optional]");
-            Console.WriteLine($"{SwitchMaxWaitSeconds}   maximum allowed duration in seconds [optional]");
-            Console.WriteLine($"{SwitchMaxConcurrency}   maximum concurrency of default.config version updates [optional]{Environment.NewLine}");
- 
-            Console.ForegroundColor = ConsoleColor.Green;
-            Console.WriteLine("Example...");
-            Console.WriteLine($">{ProgramName.Value} {SwitchDefaultConfig}c:\\default.config {SwitchManifest}c:\\manifest.json");
-            Console.ResetColor();
-        }
+		private static void ShowResults(UpdateResults results)
+		{
+			Console.ForegroundColor = results.Outcome ? ConsoleColor.Green : ConsoleColor.Red;
+			Console.WriteLine($"Completed {(results.Outcome ? "successfully" : "in a failure")}.");
+			if (!results.Outcome)
+			{
+				Console.WriteLine($"Details: {results.OutcomeDetails}.");
+			}
+			Console.ResetColor();
+			Trace.WriteLine($"Duration: {results.DurationMilliseconds:N2}-ms.");
+			Trace.WriteLine($"Successful updates: {results.UpdatedNuGets.Count():N0}.");
+			Trace.WriteLine("Updated default.config NuGet package versions...");
+			foreach (PackageUpdateResult updatedNuget in results.UpdatedNuGets.OrderBy(r => r.PackageId))
+			{
+				Trace.WriteLine($"           {updatedNuget.PackageId}: {updatedNuget.NewVersion}");
+			}
 
-        private static void ShowErrorHelpAndExit(string reason)
-        {
-            Console.ForegroundColor = ConsoleColor.Red;
-            Console.WriteLine($"Exiting due to incorrect input.  Reason: {reason}");
-            Console.ResetColor();
-            ShowHelp();
-            Environment.Exit(1);
-        }
+			if (results.PropsFileUpdateResults != null)
+			{
+				Trace.WriteLine($"Updated {results.PropsFileUpdateResults.UpdatedVariables.Count} .props files:");
+				foreach (var propsFile in results.PropsFileUpdateResults.UpdatedVariables.Where(r => r.Value.Count != 0).OrderBy(p => p.Key.Path))
+				{
+					Trace.WriteLine($"        {propsFile.Key.Path}");
+					foreach (var variableChange in propsFile.Value)
+					{
+						Trace.WriteLine($"                {variableChange.Name}={variableChange.Value}");
+					}
+				}
 
-        private static void ProcessCmdArguments(string[] args)
-        {
-            Console.ForegroundColor = ConsoleColor.DarkYellow;
-            Console.WriteLine("Processing CMD line parameters");
-            Console.ResetColor();
+				Trace.WriteLine($"{results.PropsFileUpdateResults.UnrecognizedVariables.Count} variables were not found in props files:");
+				foreach (var variable in results.PropsFileUpdateResults.UnrecognizedVariables)
+				{
+					Trace.WriteLine($"        {variable.Name} in {variable.ReferencedFilePath}");
+				}
+			}
+		}
 
-            if (args == null || args.Length < 2)
-            {
-                ShowErrorHelpAndExit("incorrect # of parameters specified");
-            }
+		private static void ShowStartOrEndMessage(string message)
+		{
+			Console.ForegroundColor = ConsoleColor.Green;
+			Console.WriteLine(message);
+			Console.ResetColor();
+		}
 
-            foreach (string arg in args!)
-            {
-                if (arg.StartsWith(SwitchDefaultConfig))
-                {
-                    ProcessArgument(arg, SwitchDefaultConfig, $"Specified {InsertionConstants.DefaultConfigFile}:", ref DefaultConfigFile);
-                }
-                else if (arg.StartsWith(SwitchManifest))
-                {
-                    ProcessArgument(arg, SwitchManifest, $"Specified {InsertionConstants.ManifestFile}:", ref ManifestFile);
-                }
-                else if (arg.StartsWith(SwitchIgnorePackages))
-                {
-                    ProcessArgument(arg, SwitchIgnorePackages, $"Specified ignored packages file:", ref IgnoredPackagesFile);
-                }
-                else if (arg.StartsWith(SwitchMaxWaitSeconds))
-                {
-                    ProcessArgumentInt(arg, SwitchMaxWaitSeconds, $"Specified \"max wait seconds\":", ref MaxWaitSeconds);
-                }
-                else if (arg.StartsWith(SwitchMaxConcurrency))
-                {
-                    ProcessArgumentInt(arg, SwitchMaxConcurrency, $"Specified \"max concurrency\":", ref MaxConcurrency);
-                }
-                else if (arg.StartsWith(SwitchIgnoreDevUxTeamPackages))
-                {
-                    IgnoreDevUxTeamPackagesScenario = true;
-                }
-            }
+		private static void ShowHelp()
+		{
+			Console.WriteLine($"{Environment.NewLine}");
+			Console.WriteLine($"{ProgramName.Value} updates versions of NuGet packages in {InsertionConstants.DefaultConfigFile} with the corresponding values from {InsertionConstants.ManifestFile}{Environment.NewLine}");
 
-            if (string.IsNullOrWhiteSpace(DefaultConfigFile))
-            {
-                ShowErrorHelpAndExit($"{InsertionConstants.DefaultConfigFile} path not set.");
-            }
-            if (string.IsNullOrWhiteSpace(ManifestFile))
-            {
-                ShowErrorHelpAndExit($"{InsertionConstants.ManifestFile} path not set.");
-            }
-        }
+			Console.WriteLine($"Usage:");
+			Console.WriteLine($">{ProgramName.Value}.exe {HelpParameters.Value}");
 
-        private static void ProcessArgument(string argument, string appSwitch, string cmdLineMessage, ref string target)
-        {
-            target = argument.Replace(appSwitch, string.Empty);
-            Trace.WriteLine($"CMD line param. {cmdLineMessage} {target}");
-        }
+			Console.WriteLine($"{Environment.NewLine}Options:");
+			Console.WriteLine($"{SwitchDefaultConfig}   full path on disk to default.config to update");
+			Console.WriteLine($"{SwitchManifest}   full path on disk to manifest.json");
+			Console.WriteLine($"{SwitchIgnorePackages}   full path on disk to ignored packages file. Each line should have a package id [optional]");
+			Console.WriteLine($"{SwitchPropsFilesRootDir}   directory to search for and update .props files [optional]");
+			Console.WriteLine($"{FeedAccessToken}   token to access nuget feed. Necessary when updating props files [optional]");
+			Console.WriteLine($"{SwitchMaxWaitSeconds}   maximum allowed duration in seconds [optional]");
+			Console.WriteLine($"{SwitchMaxConcurrency}   maximum concurrency of default.config version updates [optional]{Environment.NewLine}");
 
-        private static void ProcessArgumentInt(string argument, string appSwitch, string cmdLineMessage, ref int target)
-        {
-            string trimmedArg = argument.Replace(appSwitch, string.Empty);
-            if (int.TryParse(trimmedArg, out target))
-            {
-                Trace.WriteLine($"CMD line param. {cmdLineMessage} {target}");
-            }
-            else
-            {
-                target = -1;
-                Trace.WriteLine("Specified value is not an integer. Default value will be used.");
-            }
-        }
-    }
+			Console.ForegroundColor = ConsoleColor.Green;
+			Console.WriteLine("Example...");
+			Console.WriteLine($">{ProgramName.Value} {SwitchDefaultConfig}c:\\default.config {SwitchManifest}c:\\manifest.json");
+			Console.ResetColor();
+		}
+
+		private static void ShowErrorHelpAndExit(string reason)
+		{
+			Console.ForegroundColor = ConsoleColor.Red;
+			Console.WriteLine($"Exiting due to incorrect input.  Reason: {reason}");
+			Console.ResetColor();
+			ShowHelp();
+			Environment.Exit(1);
+		}
+
+		private static void ProcessCmdArguments(string[] args)
+		{
+			Console.ForegroundColor = ConsoleColor.DarkYellow;
+			Console.WriteLine("Processing CMD line parameters");
+			Console.ResetColor();
+
+			if (args == null || args.Length < 2)
+			{
+				ShowErrorHelpAndExit("incorrect # of parameters specified");
+			}
+
+			foreach (string arg in args!)
+			{
+				if (arg.StartsWith(SwitchDefaultConfig))
+				{
+					ProcessArgument(arg, SwitchDefaultConfig, $"Specified {InsertionConstants.DefaultConfigFile}:", ref DefaultConfigFile);
+				}
+				else if (arg.StartsWith(SwitchManifest))
+				{
+					ProcessArgument(arg, SwitchManifest, $"Specified {InsertionConstants.ManifestFile}:", ref ManifestFile);
+				}
+				else if (arg.StartsWith(SwitchIgnorePackages))
+				{
+					ProcessArgument(arg, SwitchIgnorePackages, $"Specified ignored packages file:", ref IgnoredPackagesFile);
+				}
+				else if (arg.StartsWith(SwitchPropsFilesRootDir))
+				{
+					ProcessArgument(arg, SwitchPropsFilesRootDir, $"Specified root directory for props files:", ref PropsFilesRootDirectory);
+				}
+				else if (arg.StartsWith(SwitchFeedAccessToken))
+				{
+					FeedAccessToken = arg.Replace(SwitchFeedAccessToken, string.Empty);
+					Trace.WriteLine($"CMD line param. An access token was specified.");
+				}
+				else if (arg.StartsWith(SwitchMaxWaitSeconds))
+				{
+					ProcessArgumentInt(arg, SwitchMaxWaitSeconds, $"Specified \"max wait seconds\":", ref MaxWaitSeconds);
+				}
+				else if (arg.StartsWith(SwitchMaxConcurrency))
+				{
+					ProcessArgumentInt(arg, SwitchMaxConcurrency, $"Specified \"max concurrency\":", ref MaxConcurrency);
+				}
+				else if (arg.StartsWith(SwitchIgnoreDevUxTeamPackages))
+				{
+					IgnoreDevUxTeamPackagesScenario = true;
+				}
+			}
+
+			if (string.IsNullOrWhiteSpace(DefaultConfigFile))
+			{
+				ShowErrorHelpAndExit($"{InsertionConstants.DefaultConfigFile} path not set.");
+			}
+			if (string.IsNullOrWhiteSpace(ManifestFile))
+			{
+				ShowErrorHelpAndExit($"{InsertionConstants.ManifestFile} path not set.");
+			}
+		}
+
+		private static void ProcessArgument(string argument, string appSwitch, string cmdLineMessage, ref string target)
+		{
+			target = argument.Replace(appSwitch, string.Empty);
+			Trace.WriteLine($"CMD line param. {cmdLineMessage} {target}");
+		}
+
+		private static void ProcessArgumentInt(string argument, string appSwitch, string cmdLineMessage, ref int target)
+		{
+			string trimmedArg = argument.Replace(appSwitch, string.Empty);
+			if (int.TryParse(trimmedArg, out target))
+			{
+				Trace.WriteLine($"CMD line param. {cmdLineMessage} {target}");
+			}
+			else
+			{
+				target = -1;
+				Trace.WriteLine("Specified value is not an integer. Default value will be used.");
+			}
+		}
+	}
 }

--- a/src/InsertionsClient/InsertionsClient.csproj
+++ b/src/InsertionsClient/InsertionsClient.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -8,5 +8,10 @@
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
+
+
+  <ItemGroup>
+    <PackageReference Include="NuGet.Protocol" Version="5.5.1" />
+  </ItemGroup>
 
 </Project>

--- a/src/InsertionsClient/Models/PackageUpdateResult.cs
+++ b/src/InsertionsClient/Models/PackageUpdateResult.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Net.Insertions.Models
         /// <param name="packageId">Id of the package that was updated.</param>
         /// <param name="previousVersion">Version of the package before the change.</param>
         /// <param name="newVersion">Version of the package after the change.</param>
-        public PackageUpdateResult(string packageId, string previousVersion, string newVersion)
+        internal PackageUpdateResult(string packageId, string previousVersion, string newVersion)
         {
             PackageId = packageId;
             PreviousVersion = previousVersion;

--- a/src/InsertionsClient/Models/PackageUpdateResult.cs
+++ b/src/InsertionsClient/Models/PackageUpdateResult.cs
@@ -4,49 +4,49 @@ using System;
 
 namespace Microsoft.Net.Insertions.Models
 {
-	/// <summary>
-	/// Stores the result of a package version update operation
-	/// </summary>
-	public struct PackageUpdateResult : IEquatable<PackageUpdateResult>
-	{
-		/// <summary>
-		/// Id of the package that was updated.
-		/// </summary>
-		public string PackageId { get; private set; }
+    /// <summary>
+    /// Stores the result of a package version update operation
+    /// </summary>
+    public struct PackageUpdateResult : IEquatable<PackageUpdateResult>
+    {
+        /// <summary>
+        /// Id of the package that was updated.
+        /// </summary>
+        public string PackageId { get; private set; }
 
-		/// <summary>
-		/// Version of the package before the change.
-		/// </summary>
-		public string PreviousVersion { get; private set; }
+        /// <summary>
+        /// Version of the package before the change.
+        /// </summary>
+        public string PreviousVersion { get; private set; }
 
-		/// <summary>
-		/// Version of the package after the change.
-		/// </summary>
-		public string NewVersion { get; private set; }
+        /// <summary>
+        /// Version of the package after the change.
+        /// </summary>
+        public string NewVersion { get; private set; }
 
-		/// <summary>
-		/// Creates an instance of PackageUpdateResult.
-		/// </summary>
-		/// <param name="packageId">Id of the package that was updated.</param>
-		/// <param name="previousVersion">Version of the package before the change.</param>
-		/// <param name="newVersion">Version of the package after the change.</param>
-		public PackageUpdateResult(string packageId, string previousVersion, string newVersion)
-		{
-			PackageId = packageId;
-			PreviousVersion = previousVersion;
-			NewVersion = newVersion;
-		}
+        /// <summary>
+        /// Creates an instance of PackageUpdateResult.
+        /// </summary>
+        /// <param name="packageId">Id of the package that was updated.</param>
+        /// <param name="previousVersion">Version of the package before the change.</param>
+        /// <param name="newVersion">Version of the package after the change.</param>
+        public PackageUpdateResult(string packageId, string previousVersion, string newVersion)
+        {
+            PackageId = packageId;
+            PreviousVersion = previousVersion;
+            NewVersion = newVersion;
+        }
 
-		/// <summary>
-		/// Compares given instance to this.
-		/// </summary>
-		/// <param name="other">Instance to compare to this.</param>
-		/// <returns>True if both instances have the same data. False otherwise.</returns>
-		public bool Equals(PackageUpdateResult other)
-		{
-			return PackageId == other.PackageId &&
-				PreviousVersion == other.PreviousVersion &&
-				NewVersion == other.NewVersion;
-		}
-	}
+        /// <summary>
+        /// Compares given instance to this.
+        /// </summary>
+        /// <param name="other">Instance to compare to this.</param>
+        /// <returns>True if both instances have the same data. False otherwise.</returns>
+        public bool Equals(PackageUpdateResult other)
+        {
+            return PackageId == other.PackageId &&
+                PreviousVersion == other.PreviousVersion &&
+                NewVersion == other.NewVersion;
+        }
+    }
 }

--- a/src/InsertionsClient/Models/UpdateResults.cs
+++ b/src/InsertionsClient/Models/UpdateResults.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Net.Insertions.Models
         /// <summary>
         /// Adds the given package to the updated nuget list.
         /// </summary>
-        public void AddPackage(PackageUpdateResult packageUpdateResult)
+        internal void AddPackage(PackageUpdateResult packageUpdateResult)
         {
             _updatedNugetsList.Add(packageUpdateResult);
         }

--- a/src/InsertionsClient/Models/UpdateResults.cs
+++ b/src/InsertionsClient/Models/UpdateResults.cs
@@ -1,61 +1,67 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using Microsoft.Net.Insertions.Props.Models;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace Microsoft.Net.Insertions.Models
 {
-    /// <summary>
-    /// Describes the response to <see cref="IInsertionApi.UpdateVersions(string, string, string)"/> calls.
-    /// </summary>
-    public sealed class UpdateResults
-    {
-        private readonly ConcurrentBag<PackageUpdateResult> _updatedNugetsList = new ConcurrentBag<PackageUpdateResult>();
+	/// <summary>
+	/// Describes the response to <see cref="IInsertionApi.UpdateVersions(string, string, string)"/> calls.
+	/// </summary>
+	public sealed class UpdateResults
+	{
+		private readonly ConcurrentBag<PackageUpdateResult> _updatedNugetsList = new ConcurrentBag<PackageUpdateResult>();
 
 
-        /// <summary>
-        /// True if the <see cref="IInsertionApi.UpdateVersions(string, string, string)"/> attempt completed, false otherwise.
-        /// </summary>
-        public bool Outcome => string.IsNullOrWhiteSpace(OutcomeDetails);
+		/// <summary>
+		/// True if the <see cref="IInsertionApi.UpdateVersions(string, string, string)"/> attempt completed, false otherwise.
+		/// </summary>
+		public bool Outcome => string.IsNullOrWhiteSpace(OutcomeDetails);
 
-        /// <summary>
-        /// Updated default.config NuGet package versions.
-        /// </summary>
-        public IEnumerable<PackageUpdateResult> UpdatedNuGets => _updatedNugetsList;
+		/// <summary>
+		/// Updated default.config NuGet package versions.
+		/// </summary>
+		public IEnumerable<PackageUpdateResult> UpdatedNuGets => _updatedNugetsList;
 
-        /// <summary>
-        /// Ids of ignored nuget packages.
-        /// </summary>
-        public HashSet<string>? IgnoredNuGets { get; set; }
+		/// <summary>
+		/// Ids of ignored nuget packages.
+		/// </summary>
+		public HashSet<string>? IgnoredNuGets { get; set; }
 
-        /// <summary>
-        /// Duration in ms of <see cref="IInsertionApi.UpdateVersions(string, string, string)"/> attempt.
-        /// </summary>
-        public float DurationMilliseconds { get; set; }
+		/// <summary>
+		/// Duration in ms of <see cref="IInsertionApi.UpdateVersions(string, string, string)"/> attempt.
+		/// </summary>
+		public float DurationMilliseconds { get; set; }
 
-        /// <summary>
-        /// Describes the outcome of failed <see cref="IInsertionApi.UpdateVersions(string, string, string)"/> attempts.
-        /// </summary>
-        public string? OutcomeDetails { get; set; }
+		/// <summary>
+		/// Describes the outcome of failed <see cref="IInsertionApi.UpdateVersions(string, string, string)"/> attempts.
+		/// </summary>
+		public string? OutcomeDetails { get; set; }
 
-        /// <summary>
-        /// All the files that were modified during the update or
-        /// the exceptions if there was an error while saving the file.
-        /// </summary>
-        public FileSaveResult[]? FileSaveResults { get; set; }
+		/// <summary>
+		/// All the files that were modified during the update or
+		/// the exceptions if there was an error while saving the file.
+		/// </summary>
+		public FileSaveResult[]? FileSaveResults { get; set; }
 
-        /// <summary>
-        /// Adds the given package to the updated nuget list.
-        /// </summary>
-        public void AddPackage(PackageUpdateResult packageUpdateResult)
-        {
-            _updatedNugetsList.Add(packageUpdateResult);
-        }
+		/// <summary>
+		/// Results of the props file update stage. Null, if stage didn't run.
+		/// </summary>
+		public PropsUpdateResults? PropsFileUpdateResults { get; set; }
 
-        public override string ToString()
-        {
-            return $"Validation {(Outcome ? "succeeded" : "failed")} with {UpdatedNuGets.Count()} matched assets ({DurationMilliseconds:N0}-ms)";
-        }
-    }
+		/// <summary>
+		/// Adds the given package to the updated nuget list.
+		/// </summary>
+		public void AddPackage(PackageUpdateResult packageUpdateResult)
+		{
+			_updatedNugetsList.Add(packageUpdateResult);
+		}
+
+		public override string ToString()
+		{
+			return $"Validation {(Outcome ? "succeeded" : "failed")} with {UpdatedNuGets.Count()} matched assets ({DurationMilliseconds:N0}-ms)";
+		}
+	}
 }

--- a/src/InsertionsClient/Models/UpdateResults.cs
+++ b/src/InsertionsClient/Models/UpdateResults.cs
@@ -7,61 +7,61 @@ using System.Linq;
 
 namespace Microsoft.Net.Insertions.Models
 {
-	/// <summary>
-	/// Describes the response to <see cref="IInsertionApi.UpdateVersions(string, string, string)"/> calls.
-	/// </summary>
-	public sealed class UpdateResults
-	{
-		private readonly ConcurrentBag<PackageUpdateResult> _updatedNugetsList = new ConcurrentBag<PackageUpdateResult>();
+    /// <summary>
+    /// Describes the response to <see cref="IInsertionApi.UpdateVersions(string, string, string)"/> calls.
+    /// </summary>
+    public sealed class UpdateResults
+    {
+        private readonly ConcurrentBag<PackageUpdateResult> _updatedNugetsList = new ConcurrentBag<PackageUpdateResult>();
 
 
-		/// <summary>
-		/// True if the <see cref="IInsertionApi.UpdateVersions(string, string, string)"/> attempt completed, false otherwise.
-		/// </summary>
-		public bool Outcome => string.IsNullOrWhiteSpace(OutcomeDetails);
+        /// <summary>
+        /// True if the <see cref="IInsertionApi.UpdateVersions(string, string, string)"/> attempt completed, false otherwise.
+        /// </summary>
+        public bool Outcome => string.IsNullOrWhiteSpace(OutcomeDetails);
 
-		/// <summary>
-		/// Updated default.config NuGet package versions.
-		/// </summary>
-		public IEnumerable<PackageUpdateResult> UpdatedNuGets => _updatedNugetsList;
+        /// <summary>
+        /// Updated default.config NuGet package versions.
+        /// </summary>
+        public IEnumerable<PackageUpdateResult> UpdatedNuGets => _updatedNugetsList;
 
-		/// <summary>
-		/// Ids of ignored nuget packages.
-		/// </summary>
-		public HashSet<string>? IgnoredNuGets { get; set; }
+        /// <summary>
+        /// Ids of ignored nuget packages.
+        /// </summary>
+        public HashSet<string>? IgnoredNuGets { get; set; }
 
-		/// <summary>
-		/// Duration in ms of <see cref="IInsertionApi.UpdateVersions(string, string, string)"/> attempt.
-		/// </summary>
-		public float DurationMilliseconds { get; set; }
+        /// <summary>
+        /// Duration in ms of <see cref="IInsertionApi.UpdateVersions(string, string, string)"/> attempt.
+        /// </summary>
+        public float DurationMilliseconds { get; set; }
 
-		/// <summary>
-		/// Describes the outcome of failed <see cref="IInsertionApi.UpdateVersions(string, string, string)"/> attempts.
-		/// </summary>
-		public string? OutcomeDetails { get; set; }
+        /// <summary>
+        /// Describes the outcome of failed <see cref="IInsertionApi.UpdateVersions(string, string, string)"/> attempts.
+        /// </summary>
+        public string? OutcomeDetails { get; set; }
 
-		/// <summary>
-		/// All the files that were modified during the update or
-		/// the exceptions if there was an error while saving the file.
-		/// </summary>
-		public FileSaveResult[]? FileSaveResults { get; set; }
+        /// <summary>
+        /// All the files that were modified during the update or
+        /// the exceptions if there was an error while saving the file.
+        /// </summary>
+        public FileSaveResult[]? FileSaveResults { get; set; }
 
-		/// <summary>
-		/// Results of the props file update stage. Null, if stage didn't run.
-		/// </summary>
-		public PropsUpdateResults? PropsFileUpdateResults { get; set; }
+        /// <summary>
+        /// Results of the props file update stage. Null, if stage didn't run.
+        /// </summary>
+        public PropsUpdateResults? PropsFileUpdateResults { get; set; }
 
-		/// <summary>
-		/// Adds the given package to the updated nuget list.
-		/// </summary>
-		public void AddPackage(PackageUpdateResult packageUpdateResult)
-		{
-			_updatedNugetsList.Add(packageUpdateResult);
-		}
+        /// <summary>
+        /// Adds the given package to the updated nuget list.
+        /// </summary>
+        public void AddPackage(PackageUpdateResult packageUpdateResult)
+        {
+            _updatedNugetsList.Add(packageUpdateResult);
+        }
 
-		public override string ToString()
-		{
-			return $"Validation {(Outcome ? "succeeded" : "failed")} with {UpdatedNuGets.Count()} matched assets ({DurationMilliseconds:N0}-ms)";
-		}
-	}
+        public override string ToString()
+        {
+            return $"Validation {(Outcome ? "succeeded" : "failed")} with {UpdatedNuGets.Count()} matched assets ({DurationMilliseconds:N0}-ms)";
+        }
+    }
 }

--- a/src/InsertionsClient/Telemetry/DescriptiveStatistics.cs
+++ b/src/InsertionsClient/Telemetry/DescriptiveStatistics.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Net.Insertions.Telemetry
         public override string ToString()
         {
             StringBuilder txt = new StringBuilder();
-            _ = txt.AppendLine($"No. Items: {N}");
+            _ = txt.AppendLine($"No. Items: {N:n0}");
             _ = txt.AppendLine($"Average: {Average:N4}-ms");
             _ = txt.AppendLine($"Minimum: {Minimum:N4}-ms");
             _ = txt.AppendLine($"Maximum: {Maximum:N4}-ms");

--- a/src/InsertionsClient/Telemetry/MeasurementsSession.cs
+++ b/src/InsertionsClient/Telemetry/MeasurementsSession.cs
@@ -2,14 +2,13 @@
 
 using Microsoft.Net.Insertions.Models;
 using Microsoft.Net.Insertions.Telemetry.Models;
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace Microsoft.Net.Insertions.Telemetry
 {
-    internal sealed class MeasurementsSession
+	internal sealed class MeasurementsSession
     {
         private readonly ConcurrentBag<Measurement> _dataPoints = new ConcurrentBag<Measurement>();
 

--- a/src/InsertionsClient/Telemetry/MeasurementsSession.cs
+++ b/src/InsertionsClient/Telemetry/MeasurementsSession.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace Microsoft.Net.Insertions.Telemetry
 {
-	internal sealed class MeasurementsSession
+    internal sealed class MeasurementsSession
     {
         private readonly ConcurrentBag<Measurement> _dataPoints = new ConcurrentBag<Measurement>();
 

--- a/tests/InsertionsClientTest/Assets/dotNetCoreVersions.props
+++ b/tests/InsertionsClientTest/Assets/dotNetCoreVersions.props
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(_NTBINDIR)\SetupPackages\Group\ddswixgroup.props" />
+  <PropertyGroup>
+    <PackagePreprocessorDefinitions>
+      $(PackagePreprocessorDefinitions);
+      <!-- Versions for .NET Core packages manufactured in the 'dotnet/core-setup' repo. -->
+      NetCoreAppHostPack30Version=3.0.3;
+      NetCoreAppHostPack31Version=3.1.2;
+      NetCoreHostFXRVersion=3.1.2;
+      NetCoreSharedFramework21Version=2.1.16;
+      NetCoreSharedFramework22Version=2.2.8;
+      NetCoreSharedFramework30Version=3.0.3;
+      NetCoreSharedFramework31Version=3.1.2;
+      NetCoreSharedHostVersion=3.1.2;
+      NetCoreTargetingPack30Version=3.0.0;
+      NetCoreTargetingPack31Version=3.1.0;
+      NetStandardTargetingPack21Version=2.1.0;
+      WindowsDesktopSharedFramework30Version=3.0.3;
+      WindowsDesktopSharedFramework31Version=3.1.2;
+      WindowsDesktopTargetingPack30Version=3.0.0;
+      WindowsDesktopTargetingPack31Version=3.1.0;
+      <!-- Versions for .NET Core packages manufactured in the 'dotnet/core-sdk' repo. -->
+      NetCoreSdkPlaceholderVersion=3.1.102-servicing-014873;
+      NetCoreTemplates21Version=3.1.300-preview-015048;
+      NetCoreTemplates22Version=3.1.100-rtm-014727;
+      NetCoreTemplates30Version=3.1.300-preview-015048;
+      NetCoreTemplates31Version=3.1.102-servicing-014873;
+      NetCoreToolsetVersion=3.1.102;
+      <!-- Versions for .NET Core packages manufactured in the 'aspnet/aspnetcore' repo. -->
+      AspNetCoreSharedFramework21Version=2.1.16;
+      AspNetCoreSharedFramework22Version=2.2.8;
+      AspNetCoreSharedFramework30Version=3.0.3;
+      AspNetCoreSharedFramework31Version=3.1.2;
+      AspNetCoreTargetingPack30Version=3.0.1;
+      AspNetCoreTargetingPack31Version=3.1.2;
+    </PackagePreprocessorDefinitions>
+  </PropertyGroup>
+</Project>

--- a/tests/InsertionsClientTest/Assets/msi.swr
+++ b/tests/InsertionsClientTest/Assets/msi.swr
@@ -1,0 +1,25 @@
+use vs
+
+package name=Microsoft.NetCore.AppHostPack.3.1.$(NetCoreAppHostPack31Version).x64
+        version=$(ProductsBuildVersion)
+        vs.package.type=msi
+        vs.package.branch=$(VsSingletonPackageBranch)
+        vs.package.chip=x86
+        license=https://github.com/dotnet/core-setup
+        vs.package.internalRevision=$(PackageInternalRevision)
+
+vs.installSize
+  SystemDrive=1269236
+  TargetDrive=0
+  SharedDrive=0
+
+vs.logFiles
+  vs.logFile pattern="dd_setup*Microsoft.NetCore.AppHostPack.3.1.x86_x64*.log"
+
+vs.msiProperties
+  vs.msiProperty name="DOTNETHOME" value="[ProgramFilesX86]dotnet"
+  vs.msiProperty Name="ALLOWMSIINSTALL" Value="True"
+
+vs.payloads
+  vs.payload source=!(bindpath.sources)\Redist\common\NetCoreSDK\NetCoreAppHostPack_3.1\x86_x64\dotnet-apphost-pack-$(NetCoreAppHostPack31Version)-win-x86_x64.msi
+  vs.payload source=path\to\extract\runtimes\win-x64\native\$(AspNetCoreTargetingPack30Version).exe

--- a/tests/InsertionsClientTest/DefaultConfigUpdaterTest.cs
+++ b/tests/InsertionsClientTest/DefaultConfigUpdaterTest.cs
@@ -8,108 +8,108 @@ using System.IO;
 
 namespace InsertionsClientTest
 {
-	[TestClass]
-	public class DefaultConfigUpdaterTest
-	{
-		/// <summary>
-		/// Tests the behaviour when config file path is null or points to a nonexistent file.
-		/// </summary>
-		/// <param name="configFilePath">Path to default.config</param>
-		[TestMethod]
-		[DataRow(null, DisplayName = "Null config path")]
-		[DataRow("some nonexistent file.txt", DisplayName = "Nonexistent config file")]
-		public void TestLoadWrongFile(string configFilePath)
-		{
-			DefaultConfigUpdater updater = new DefaultConfigUpdater();
-			Assert.IsFalse(updater.TryLoad(configFilePath, out string error));
-			Assert.IsFalse(string.IsNullOrWhiteSpace(error));
-		}
+    [TestClass]
+    public class DefaultConfigUpdaterTest
+    {
+        /// <summary>
+        /// Tests the behaviour when config file path is null or points to a nonexistent file.
+        /// </summary>
+        /// <param name="configFilePath">Path to default.config</param>
+        [TestMethod]
+        [DataRow(null, DisplayName = "Null config path")]
+        [DataRow("some nonexistent file.txt", DisplayName = "Nonexistent config file")]
+        public void TestLoadWrongFile(string configFilePath)
+        {
+            DefaultConfigUpdater updater = new DefaultConfigUpdater();
+            Assert.IsFalse(updater.TryLoad(configFilePath, out string error));
+            Assert.IsFalse(string.IsNullOrWhiteSpace(error));
+        }
 
-		/// <summary>
-		/// Attempts to load a sample default.config file and related .packageconfig files
-		/// </summary>
-		[TestMethod]
-		public void TestLoadFile()
-		{
-			CreateAndLoadDefaultConfigUpdater();
-		}
+        /// <summary>
+        /// Attempts to load a sample default.config file and related .packageconfig files
+        /// </summary>
+        [TestMethod]
+        public void TestLoadFile()
+        {
+            CreateAndLoadDefaultConfigUpdater();
+        }
 
-		/// <summary>
-		/// Attempts to change only 1 of the package versions, then saves the results.
-		/// Checks if one and only one file was modified.
-		/// Checks if modification was successful.
-		/// 2 package ids are tested: one lies within default.config, the other lies within a packageconfig
-		/// </summary>
-		/// <param name="packageId">Id of the package to change the version of</param>
-		[TestMethod]
-		[DataRow("VS.Tools.Roslyn", DisplayName = "Update default.config content")]
-		[DataRow("Microsoft.IdentityModel.Clients.ActiveDirectory", DisplayName = "Update packageconfig content")]
-		public void TestDefaultConfigContent(string packageId)
-		{
-			// Load file
-			DefaultConfigUpdater updater = CreateAndLoadDefaultConfigUpdater();
+        /// <summary>
+        /// Attempts to change only 1 of the package versions, then saves the results.
+        /// Checks if one and only one file was modified.
+        /// Checks if modification was successful.
+        /// 2 package ids are tested: one lies within default.config, the other lies within a packageconfig
+        /// </summary>
+        /// <param name="packageId">Id of the package to change the version of</param>
+        [TestMethod]
+        [DataRow("VS.Tools.Roslyn", DisplayName = "Update default.config content")]
+        [DataRow("Microsoft.IdentityModel.Clients.ActiveDirectory", DisplayName = "Update packageconfig content")]
+        public void TestDefaultConfigContent(string packageId)
+        {
+            // Load file
+            DefaultConfigUpdater updater = CreateAndLoadDefaultConfigUpdater();
 
-			// Test Content: change a version in default.config or packageconfig, depending on the input
-			Assert.IsTrue(updater.TryUpdatePackage(packageId, "1.2.3.4.5", out _));
-			FileSaveResult[] saveResults = updater.Save();
-			Assert.IsNotNull(saveResults);
-			Assert.AreEqual(1, saveResults.Length);
+            // Test Content: change a version in default.config or packageconfig, depending on the input
+            Assert.IsTrue(updater.TryUpdatePackage(packageId, "1.2.3.4.5", out _));
+            FileSaveResult[] saveResults = updater.Save();
+            Assert.IsNotNull(saveResults);
+            Assert.AreEqual(1, saveResults.Length);
 
-			Assert.IsTrue(saveResults[0].Succeeded);
-		}
+            Assert.IsTrue(saveResults[0].Succeeded);
+        }
 
-		/// <summary>
-		/// Attempts to update the version of a package that doesn't exist in config files.
-		/// Checks that no files were modified as a result of this operation.
-		/// </summary>
-		[TestMethod]
-		public void TestMissingPackageUpdate()
-		{
-			// Load file
-			DefaultConfigUpdater updater = CreateAndLoadDefaultConfigUpdater();
+        /// <summary>
+        /// Attempts to update the version of a package that doesn't exist in config files.
+        /// Checks that no files were modified as a result of this operation.
+        /// </summary>
+        [TestMethod]
+        public void TestMissingPackageUpdate()
+        {
+            // Load file
+            DefaultConfigUpdater updater = CreateAndLoadDefaultConfigUpdater();
 
-			// Update a package that doesn't exist
-			Assert.IsFalse(updater.TryUpdatePackage("Some.Package.Nobody.Created", "xxx", out _));
-			FileSaveResult[] saveResults = updater.Save();
-			Assert.IsNotNull(saveResults);
-			Assert.AreEqual(0, saveResults.Length);
-		}
+            // Update a package that doesn't exist
+            Assert.IsFalse(updater.TryUpdatePackage("Some.Package.Nobody.Created", "xxx", out _));
+            FileSaveResult[] saveResults = updater.Save();
+            Assert.IsNotNull(saveResults);
+            Assert.AreEqual(0, saveResults.Length);
+        }
 
-		/// <summary>
-		/// Changes the version number of a package to a GUID. Opens and reads the saved file to check
-		/// if the GUID really exists in it or not.
-		/// 2 package ids are tested: one lies within default.config, the other lies within a packageconfig
-		/// </summary>
-		/// <param name="packageId">Id of the package to change the version of</param>
-		[TestMethod]
-		[DataRow("VS.Redist.X86.Retail.Bin.I386.HelpDocs.Intellisense.NETPortableV4_0.1055", DisplayName = "Version number set: default.config")]
-		[DataRow("Microsoft.VisualStudio.Language.NavigateTo.Implementation", DisplayName = "Version number set: packageconfig")]
-		public void TestSetCorrectVersionDefaultConfig(string packageId)
-		{
-			// Load file
-			DefaultConfigUpdater updater = CreateAndLoadDefaultConfigUpdater();
+        /// <summary>
+        /// Changes the version number of a package to a GUID. Opens and reads the saved file to check
+        /// if the GUID really exists in it or not.
+        /// 2 package ids are tested: one lies within default.config, the other lies within a packageconfig
+        /// </summary>
+        /// <param name="packageId">Id of the package to change the version of</param>
+        [TestMethod]
+        [DataRow("VS.Redist.X86.Retail.Bin.I386.HelpDocs.Intellisense.NETPortableV4_0.1055", DisplayName = "Version number set: default.config")]
+        [DataRow("Microsoft.VisualStudio.Language.NavigateTo.Implementation", DisplayName = "Version number set: packageconfig")]
+        public void TestSetCorrectVersionDefaultConfig(string packageId)
+        {
+            // Load file
+            DefaultConfigUpdater updater = CreateAndLoadDefaultConfigUpdater();
 
-			// Test Content
-			string versionNumber = Guid.NewGuid().ToString();
-			// Edit a package that is inside default.config or .packageconfig depending on the input
-			Assert.IsTrue(updater.TryUpdatePackage(packageId, versionNumber, out _));
-			FileSaveResult[] saveResults = updater.Save();
-			Assert.IsNotNull(saveResults);
-			Assert.AreEqual(1, saveResults.Length);
+            // Test Content
+            string versionNumber = Guid.NewGuid().ToString();
+            // Edit a package that is inside default.config or .packageconfig depending on the input
+            Assert.IsTrue(updater.TryUpdatePackage(packageId, versionNumber, out _));
+            FileSaveResult[] saveResults = updater.Save();
+            Assert.IsNotNull(saveResults);
+            Assert.AreEqual(1, saveResults.Length);
 
-			Assert.IsTrue(saveResults[0].Succeeded);
-			Assert.IsTrue(File.ReadAllText(saveResults[0].Path).Contains(versionNumber), "Written version number was not found in the saved file.");
-		}
+            Assert.IsTrue(saveResults[0].Succeeded);
+            Assert.IsTrue(File.ReadAllText(saveResults[0].Path).Contains(versionNumber), "Written version number was not found in the saved file.");
+        }
 
-		private DefaultConfigUpdater CreateAndLoadDefaultConfigUpdater()
-		{
-			DefaultConfigUpdater updater = new DefaultConfigUpdater();
-			string defaultConfigPath = Path.Combine(Environment.CurrentDirectory, "Assets", "default.config");
-			Assert.IsTrue(File.Exists(defaultConfigPath));
-			Assert.IsTrue(updater.TryLoad(defaultConfigPath, out string error), error);
-			Assert.IsTrue(string.IsNullOrEmpty(error));
+        private DefaultConfigUpdater CreateAndLoadDefaultConfigUpdater()
+        {
+            DefaultConfigUpdater updater = new DefaultConfigUpdater();
+            string defaultConfigPath = Path.Combine(Environment.CurrentDirectory, "Assets", "default.config");
+            Assert.IsTrue(File.Exists(defaultConfigPath));
+            Assert.IsTrue(updater.TryLoad(defaultConfigPath, out string error), error);
+            Assert.IsTrue(string.IsNullOrEmpty(error));
 
-			return updater;
-		}
-	}
+            return updater;
+        }
+    }
 }

--- a/tests/InsertionsClientTest/InsertionApiTest.cs
+++ b/tests/InsertionsClientTest/InsertionApiTest.cs
@@ -30,17 +30,17 @@ namespace InsertionsClientTest
 
             results = ignoreCase switch
             {
-                IgnoreCase.DefaultDevUxTeamPackages => api.UpdateVersions(manifestFile, defaultConfigFile, InsertionConstants.DefaultDevUxTeamPackages),
-                IgnoreCase.SpecifiedFile => api.UpdateVersions(manifestFile, defaultConfigFile, Path.Combine(assetsDirectory, "ignored.txt")),
-                _ => api.UpdateVersions(manifestFile, defaultConfigFile),
+                IgnoreCase.DefaultDevUxTeamPackages => api.UpdateVersions(manifestFile, defaultConfigFile, InsertionConstants.DefaultDevUxTeamPackages, null, null),
+                IgnoreCase.SpecifiedFile => api.UpdateVersions(manifestFile, defaultConfigFile, Path.Combine(assetsDirectory, "ignored.txt"), null, null),
+                _ => api.UpdateVersions(manifestFile, defaultConfigFile, (HashSet<string>?)null, null, null),
             };
 
             Assert.IsTrue(ListsAreEquivalent(ignoreCase, results?.IgnoredNuGets), $"Mismatched ignore packages for {ignoreCase}");
         }
 
-        private bool ListsAreEquivalent(IgnoreCase ignoreCase, HashSet<string> results)
+        private bool ListsAreEquivalent(IgnoreCase ignoreCase, HashSet<string>? results)
         {
-            HashSet<string> expected = ignoreCase switch
+            HashSet<string>? expected = ignoreCase switch
             {
                 IgnoreCase.DefaultDevUxTeamPackages => InsertionConstants.DefaultDevUxTeamPackages,
                 IgnoreCase.SpecifiedFile =>

--- a/tests/InsertionsClientTest/InsertionsClientTest.csproj
+++ b/tests/InsertionsClientTest/InsertionsClientTest.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/InsertionsClientTest/InsertionsClientTest.csproj
+++ b/tests/InsertionsClientTest/InsertionsClientTest.csproj
@@ -110,6 +110,9 @@
     <None Update="Assets\DotNetCoreSDK\Toolset.packageconfig">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Assets\dotNetCoreVersions.props">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Assets\ignored.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -141,6 +144,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="Assets\Microsoft.VisualStudio.MinShell\vs-validation.packageconfig">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Assets\msi.swr">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="Assets\TargetingPacks.packageconfig">

--- a/tests/InsertionsClientTest/ManifestTest.cs
+++ b/tests/InsertionsClientTest/ManifestTest.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.Net.Insertions.Models;
-using Microsoft.Net.Insertions.Common.Json;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.IO;
-using System;
 using Microsoft.Net.Insertions.Api.Providers;
+using Microsoft.Net.Insertions.Common.Json;
+using Microsoft.Net.Insertions.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace DefaultConfigClientTest

--- a/tests/InsertionsClientTest/PropsTests.cs
+++ b/tests/InsertionsClientTest/PropsTests.cs
@@ -141,10 +141,11 @@ namespace InsertionsClientTest
             SwrFile swrFile = loadedSwrFiles.First(s => s.Path == swrPath);
 
             PropsVariableDeducer variableDeducer = new PropsVariableDeducer("https://api.nuget.org/v3/index.json", null);
-            List<PropsFileVariableReference>? results = variableDeducer.DeduceVariableValues(defaultConfigUpdater,
+            bool operationResult = variableDeducer.DeduceVariableValues(defaultConfigUpdater,
                 new[] { new PackageUpdateResult("runtime.win-x64.Microsoft.NETCore.DotNetAppHost", "unimportant", "3.1.3") },
-                new SwrFile[] { swrFile });
+                new SwrFile[] { swrFile }, out List<PropsFileVariableReference> results, out string details);
 
+            Assert.IsTrue(operationResult);
             Assert.IsNotNull(results);
             Assert.IsTrue(results.Any(r => r.ReferencedFilePath == swrPath), "Cannot find the value of variable in given swr.");
             Assert.IsTrue(results.Any(r => r.ReferencedFilePath == swrPath && r.Name == "AspNetCoreTargetingPack30Version"), "Cannot find the correct variable.");

--- a/tests/InsertionsClientTest/PropsTests.cs
+++ b/tests/InsertionsClientTest/PropsTests.cs
@@ -13,142 +13,142 @@ using System.Linq;
 
 namespace InsertionsClientTest
 {
-	[TestClass]
-	public class PropsTests
-	{
-		/// <summary>
-		/// Loads all swr files under test directory and checks if our test .swr file was found
-		/// </summary>
-		/// <param name="rootPathSuffix">Suffix to add to the end of the search directory path.</param>
-		[TestMethod]
-		[DataRow("", DisplayName = "Load swr in root directory")]
-		[DataRow("../", DisplayName = "Load swr in a child directory")]
-		[DataRow("../../", DisplayName = "Load swr in a grandchild directory")]
-		public void TestLoadSwr(string rootPathSuffix)
-		{
-			string swrPath = Path.Combine(Environment.CurrentDirectory, "Assets", "msi.swr");
-			SwrFileReader swrFileReader = new SwrFileReader(4);
+    [TestClass]
+    public class PropsTests
+    {
+        /// <summary>
+        /// Loads all swr files under test directory and checks if our test .swr file was found
+        /// </summary>
+        /// <param name="rootPathSuffix">Suffix to add to the end of the search directory path.</param>
+        [TestMethod]
+        [DataRow("", DisplayName = "Load swr in root directory")]
+        [DataRow("../", DisplayName = "Load swr in a child directory")]
+        [DataRow("../../", DisplayName = "Load swr in a grandchild directory")]
+        public void TestLoadSwr(string rootPathSuffix)
+        {
+            string swrPath = Path.Combine(Environment.CurrentDirectory, "Assets", "msi.swr");
+            SwrFileReader swrFileReader = new SwrFileReader(4);
 
-			string rootSearchPath = Path.Combine(Environment.CurrentDirectory, "Assets", rootPathSuffix);
-			rootSearchPath = new DirectoryInfo(rootSearchPath).FullName;
+            string rootSearchPath = Path.Combine(Environment.CurrentDirectory, "Assets", rootPathSuffix);
+            rootSearchPath = new DirectoryInfo(rootSearchPath).FullName;
 
-			SwrFile[] loadedSwrFiles = swrFileReader.LoadSwrFiles(rootSearchPath);
+            SwrFile[] loadedSwrFiles = swrFileReader.LoadSwrFiles(rootSearchPath);
 
-			Assert.IsTrue(loadedSwrFiles.Any(s => s.Path == swrPath));
-		}
+            Assert.IsTrue(loadedSwrFiles.Any(s => s.Path == swrPath));
+        }
 
-		/// <summary>
-		/// Check if test .swr file was loaded successfully
-		/// </summary>
-		[TestMethod]
-		public void TestLoadSwrContent()
-		{
-			string swrPath = Path.Combine(Environment.CurrentDirectory, "Assets", "msi.swr");
-			SwrFileReader swrFileReader = new SwrFileReader(4);
+        /// <summary>
+        /// Check if test .swr file was loaded successfully
+        /// </summary>
+        [TestMethod]
+        public void TestLoadSwrContent()
+        {
+            string swrPath = Path.Combine(Environment.CurrentDirectory, "Assets", "msi.swr");
+            SwrFileReader swrFileReader = new SwrFileReader(4);
 
-			SwrFile[] loadedSwrFiles = swrFileReader.LoadSwrFiles(Environment.CurrentDirectory);
+            SwrFile[] loadedSwrFiles = swrFileReader.LoadSwrFiles(Environment.CurrentDirectory);
 
-			SwrFile swrFile = loadedSwrFiles.First(s => s.Path == swrPath);
+            SwrFile swrFile = loadedSwrFiles.First(s => s.Path == swrPath);
 
-			Assert.IsNotNull(swrFile.PayloadPaths, "Swr payload list is null");
-			Assert.IsTrue(swrFile.PayloadPaths.Count > 0, "Loaded swr has no payload");
-			Assert.IsTrue(swrFile.PayloadPaths.Any(p => p.VariableName == "NetCoreAppHostPack31Version"));
-		}
+            Assert.IsNotNull(swrFile.PayloadPaths, "Swr payload list is null");
+            Assert.IsTrue(swrFile.PayloadPaths.Count > 0, "Loaded swr has no payload");
+            Assert.IsTrue(swrFile.PayloadPaths.Any(p => p.VariableName == "NetCoreAppHostPack31Version"));
+        }
 
-		/// <summary>
-		/// Attempts to find a given variable in a props file and update it.
-		/// </summary>
-		[TestMethod]
-		public void TestPropFileUpdate()
-		{
-			string msiPath = Path.Combine(Environment.CurrentDirectory, "Assets", "msi.swr");
-			PropsFileVariableReference variable = new PropsFileVariableReference("WindowsDesktopSharedFramework31Version", "3.3.3", msiPath);
+        /// <summary>
+        /// Attempts to find a given variable in a props file and update it.
+        /// </summary>
+        [TestMethod]
+        public void TestPropFileUpdate()
+        {
+            string msiPath = Path.Combine(Environment.CurrentDirectory, "Assets", "msi.swr");
+            PropsFileVariableReference variable = new PropsFileVariableReference("WindowsDesktopSharedFramework31Version", "3.3.3", msiPath);
 
-			PropsFileUpdater propsUpdater = new PropsFileUpdater();
-			PropsUpdateResults? results = propsUpdater.UpdatePropsFiles(Enumerable.Repeat(variable, 1), Environment.CurrentDirectory);
+            PropsFileUpdater propsUpdater = new PropsFileUpdater();
+            PropsUpdateResults? results = propsUpdater.UpdatePropsFiles(Enumerable.Repeat(variable, 1), Environment.CurrentDirectory);
 
-			Assert.IsNotNull(results);
-			Assert.IsTrue(results.Outcome);
+            Assert.IsNotNull(results);
+            Assert.IsTrue(results.Outcome);
 
-			if (results.UnrecognizedVariables != null)
-			{
-				Assert.AreEqual(0, results.UnrecognizedVariables.Count, "Variable was not recognized.");
-			}
+            if (results.UnrecognizedVariables != null)
+            {
+                Assert.AreEqual(0, results.UnrecognizedVariables.Count, "Variable was not recognized.");
+            }
 
-			Assert.IsNotNull(results.UpdatedVariables);
-			Assert.AreEqual(1, results.UpdatedVariables.Count);
-			Assert.IsTrue(results.UpdatedVariables.First().Value.Contains(variable), "Supplied variable is not among the updated.");
+            Assert.IsNotNull(results.UpdatedVariables);
+            Assert.AreEqual(1, results.UpdatedVariables.Count);
+            Assert.IsTrue(results.UpdatedVariables.First().Value.Contains(variable), "Supplied variable is not among the updated.");
 
-			Assert.IsNotNull(results.ModifiedFiles, "No props file was updated.");
-			Assert.AreEqual(1, results.ModifiedFiles.Count, "No props file was updated.");
-			Assert.IsTrue(results.ModifiedFiles[0].Succeeded);
-			Assert.IsNull(results.ModifiedFiles[0].Exception);
-			Assert.AreEqual("dotNetCoreVersions.props", Path.GetFileName(results.ModifiedFiles[0].Path));
-		}
+            Assert.IsNotNull(results.ModifiedFiles, "No props file was updated.");
+            Assert.AreEqual(1, results.ModifiedFiles.Count, "No props file was updated.");
+            Assert.IsTrue(results.ModifiedFiles[0].Succeeded);
+            Assert.IsNull(results.ModifiedFiles[0].Exception);
+            Assert.AreEqual("dotNetCoreVersions.props", Path.GetFileName(results.ModifiedFiles[0].Path));
+        }
 
-		/// <summary>
-		/// Uses a variable outside of the props file's scope and checks to see if props file gets updated.
-		/// Since props file isn't available for that variable, update shouldn't occur.
-		/// </summary>
-		[TestMethod]
-		public void TestPropsFileScope()
-		{
-			// swr is in the root folder while props file will be in a child folder.
-			string msiPath = Path.Combine(Environment.CurrentDirectory, "msi.swr");
-			PropsFileVariableReference variable = new PropsFileVariableReference("WindowsDesktopSharedFramework31Version", "3.3.3", msiPath);
+        /// <summary>
+        /// Uses a variable outside of the props file's scope and checks to see if props file gets updated.
+        /// Since props file isn't available for that variable, update shouldn't occur.
+        /// </summary>
+        [TestMethod]
+        public void TestPropsFileScope()
+        {
+            // swr is in the root folder while props file will be in a child folder.
+            string msiPath = Path.Combine(Environment.CurrentDirectory, "msi.swr");
+            PropsFileVariableReference variable = new PropsFileVariableReference("WindowsDesktopSharedFramework31Version", "3.3.3", msiPath);
 
-			PropsFileUpdater propsUpdater = new PropsFileUpdater();
-			PropsUpdateResults? results = propsUpdater.UpdatePropsFiles(Enumerable.Repeat(variable, 1), Environment.CurrentDirectory);
+            PropsFileUpdater propsUpdater = new PropsFileUpdater();
+            PropsUpdateResults? results = propsUpdater.UpdatePropsFiles(Enumerable.Repeat(variable, 1), Environment.CurrentDirectory);
 
-			Assert.IsNotNull(results);
-			Assert.IsTrue(results.Outcome);
+            Assert.IsNotNull(results);
+            Assert.IsTrue(results.Outcome);
 
-			Assert.IsNotNull(results.UnrecognizedVariables);
-			Assert.AreEqual(1, results.UnrecognizedVariables.Count);
-			Assert.AreEqual(variable.Name, results.UnrecognizedVariables[0].Name);
+            Assert.IsNotNull(results.UnrecognizedVariables);
+            Assert.AreEqual(1, results.UnrecognizedVariables.Count);
+            Assert.AreEqual(variable.Name, results.UnrecognizedVariables[0].Name);
 
-			Assert.AreEqual(0, results.UpdatedVariables.Count);
-			Assert.AreEqual(0, results.ModifiedFiles.Count);
-		}
+            Assert.AreEqual(0, results.UpdatedVariables.Count);
+            Assert.AreEqual(0, results.ModifiedFiles.Count);
+        }
 
-		/// <summary>
-		/// Attempts to deduce the value of a variable in an swr using a publicly available nuget package.
-		/// </summary>
-		[TestMethod]
-		public void TestVariableValueDeduce()
-		{
-			// Generate test default.config
-			string testConfig = @"<?xml version=""1.0"" encoding=""us-ascii""?>
+        /// <summary>
+        /// Attempts to deduce the value of a variable in an swr using a publicly available nuget package.
+        /// </summary>
+        [TestMethod]
+        public void TestVariableValueDeduce()
+        {
+            // Generate test default.config
+            string testConfig = @"<?xml version=""1.0"" encoding=""us-ascii""?>
 <corext>
 	<packages>
 		<package id=""runtime.win-x64.Microsoft.NETCore.DotNetAppHost"" version=""unimportant"" link=""path\to\extract"" />
 	</packages>
 </corext>";
-			string defaultConfigPath = Path.GetTempFileName();
-			File.WriteAllText(defaultConfigPath, testConfig);
+            string defaultConfigPath = Path.GetTempFileName();
+            File.WriteAllText(defaultConfigPath, testConfig);
 
-			// Load default.config
-			DefaultConfigUpdater defaultConfigUpdater = new DefaultConfigUpdater();
-			bool configLoadResult = defaultConfigUpdater.TryLoad(defaultConfigPath, out string error);
+            // Load default.config
+            DefaultConfigUpdater defaultConfigUpdater = new DefaultConfigUpdater();
+            bool configLoadResult = defaultConfigUpdater.TryLoad(defaultConfigPath, out string error);
 
-			Assert.IsTrue(configLoadResult, "Loading default.config failed.");
+            Assert.IsTrue(configLoadResult, "Loading default.config failed.");
 
-			// Load msi.swr
-			string swrPath = Path.Combine(Environment.CurrentDirectory, "Assets", "msi.swr");
-			SwrFileReader swrFileReader = new SwrFileReader(4);
+            // Load msi.swr
+            string swrPath = Path.Combine(Environment.CurrentDirectory, "Assets", "msi.swr");
+            SwrFileReader swrFileReader = new SwrFileReader(4);
 
-			SwrFile[] loadedSwrFiles = swrFileReader.LoadSwrFiles(Environment.CurrentDirectory);
-			SwrFile swrFile = loadedSwrFiles.First(s => s.Path == swrPath);
+            SwrFile[] loadedSwrFiles = swrFileReader.LoadSwrFiles(Environment.CurrentDirectory);
+            SwrFile swrFile = loadedSwrFiles.First(s => s.Path == swrPath);
 
-			PropsVariableDeducer variableDeducer = new PropsVariableDeducer("https://api.nuget.org/v3/index.json", null);
-			List<PropsFileVariableReference>? results = variableDeducer.DeduceVariableValues(defaultConfigUpdater,
-				new[] { new PackageUpdateResult("runtime.win-x64.Microsoft.NETCore.DotNetAppHost", "unimportant", "3.1.3") },
-				new SwrFile[] { swrFile });
+            PropsVariableDeducer variableDeducer = new PropsVariableDeducer("https://api.nuget.org/v3/index.json", null);
+            List<PropsFileVariableReference>? results = variableDeducer.DeduceVariableValues(defaultConfigUpdater,
+                new[] { new PackageUpdateResult("runtime.win-x64.Microsoft.NETCore.DotNetAppHost", "unimportant", "3.1.3") },
+                new SwrFile[] { swrFile });
 
-			Assert.IsNotNull(results);
-			Assert.IsTrue(results.Any(r => r.ReferencedFilePath == swrPath), "Cannot find the value of variable in given swr.");
-			Assert.IsTrue(results.Any(r => r.ReferencedFilePath == swrPath && r.Name == "AspNetCoreTargetingPack30Version"), "Cannot find the correct variable.");
-			Assert.IsTrue(results.Any(r => r.ReferencedFilePath == swrPath && r.Name == "AspNetCoreTargetingPack30Version" && r.Value == "apphost"), "Wrong value was found for the variable.");
-		}
-	}
+            Assert.IsNotNull(results);
+            Assert.IsTrue(results.Any(r => r.ReferencedFilePath == swrPath), "Cannot find the value of variable in given swr.");
+            Assert.IsTrue(results.Any(r => r.ReferencedFilePath == swrPath && r.Name == "AspNetCoreTargetingPack30Version"), "Cannot find the correct variable.");
+            Assert.IsTrue(results.Any(r => r.ReferencedFilePath == swrPath && r.Name == "AspNetCoreTargetingPack30Version" && r.Value == "apphost"), "Wrong value was found for the variable.");
+        }
+    }
 }

--- a/tests/InsertionsClientTest/PropsTests.cs
+++ b/tests/InsertionsClientTest/PropsTests.cs
@@ -51,8 +51,8 @@ namespace InsertionsClientTest
 			SwrFile swrFile = loadedSwrFiles.First(s => s.Path == swrPath);
 
 			Assert.IsNotNull(swrFile.PayloadPaths, "Swr payload list is null");
-			Assert.AreEqual(1, swrFile.PayloadPaths.Count, "Loaded swr has wrong number of payload paths");
-			Assert.AreEqual("NetCoreAppHostPack31Version", swrFile.PayloadPaths[0].VariableName);
+			Assert.IsTrue(swrFile.PayloadPaths.Count > 0, "Loaded swr has no payload");
+			Assert.IsTrue(swrFile.PayloadPaths.Any(p => p.VariableName == "NetCoreAppHostPack31Version"));
 		}
 
 		/// <summary>

--- a/tests/InsertionsClientTest/PropsTests.cs
+++ b/tests/InsertionsClientTest/PropsTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using Microsoft.Net.Insertions.Api;
-using Microsoft.Net.Insertions.Api.Models;
+using Microsoft.Net.Insertions.Api.Props.Models;
 using Microsoft.Net.Insertions.Api.Providers;
 using Microsoft.Net.Insertions.Models;
 using Microsoft.Net.Insertions.Props.Models;

--- a/tests/InsertionsClientTest/PropsTests.cs
+++ b/tests/InsertionsClientTest/PropsTests.cs
@@ -1,0 +1,154 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Net.Insertions.Api;
+using Microsoft.Net.Insertions.Api.Models;
+using Microsoft.Net.Insertions.Api.Providers;
+using Microsoft.Net.Insertions.Models;
+using Microsoft.Net.Insertions.Props.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace InsertionsClientTest
+{
+	[TestClass]
+	public class PropsTests
+	{
+		/// <summary>
+		/// Loads all swr files under test directory and checks if our test .swr file was found
+		/// </summary>
+		/// <param name="rootPathSuffix">Suffix to add to the end of the search directory path.</param>
+		[TestMethod]
+		[DataRow("", DisplayName = "Load swr in root directory")]
+		[DataRow("../", DisplayName = "Load swr in a child directory")]
+		[DataRow("../../", DisplayName = "Load swr in a grandchild directory")]
+		public void TestLoadSwr(string rootPathSuffix)
+		{
+			string swrPath = Path.Combine(Environment.CurrentDirectory, "Assets", "msi.swr");
+			SwrFileReader swrFileReader = new SwrFileReader(4);
+
+			string rootSearchPath = Path.Combine(Environment.CurrentDirectory, "Assets", rootPathSuffix);
+			rootSearchPath = new DirectoryInfo(rootSearchPath).FullName;
+
+			SwrFile[] loadedSwrFiles = swrFileReader.LoadSwrFiles(rootSearchPath);
+
+			Assert.IsTrue(loadedSwrFiles.Any(s => s.Path == swrPath));
+		}
+
+		/// <summary>
+		/// Check if test .swr file was loaded successfully
+		/// </summary>
+		[TestMethod]
+		public void TestLoadSwrContent()
+		{
+			string swrPath = Path.Combine(Environment.CurrentDirectory, "Assets", "msi.swr");
+			SwrFileReader swrFileReader = new SwrFileReader(4);
+
+			SwrFile[] loadedSwrFiles = swrFileReader.LoadSwrFiles(Environment.CurrentDirectory);
+
+			SwrFile swrFile = loadedSwrFiles.First(s => s.Path == swrPath);
+
+			Assert.IsNotNull(swrFile.PayloadPaths, "Swr payload list is null");
+			Assert.AreEqual(1, swrFile.PayloadPaths.Count, "Loaded swr has wrong number of payload paths");
+			Assert.AreEqual("NetCoreAppHostPack31Version", swrFile.PayloadPaths[0].VariableName);
+		}
+
+		/// <summary>
+		/// Attempts to find a given variable in a props file and update it.
+		/// </summary>
+		[TestMethod]
+		public void TestPropFileUpdate()
+		{
+			string msiPath = Path.Combine(Environment.CurrentDirectory, "Assets", "msi.swr");
+			PropsFileVariableReference variable = new PropsFileVariableReference("WindowsDesktopSharedFramework31Version", "3.3.3", msiPath);
+
+			PropsFileUpdater propsUpdater = new PropsFileUpdater();
+			PropsUpdateResults? results = propsUpdater.UpdatePropsFiles(Enumerable.Repeat(variable, 1), Environment.CurrentDirectory);
+
+			Assert.IsNotNull(results);
+			Assert.IsTrue(results.Outcome);
+
+			if (results.UnrecognizedVariables != null)
+			{
+				Assert.AreEqual(0, results.UnrecognizedVariables.Count, "Variable was not recognized.");
+			}
+
+			Assert.IsNotNull(results.UpdatedVariables);
+			Assert.AreEqual(1, results.UpdatedVariables.Count);
+			Assert.IsTrue(results.UpdatedVariables.First().Value.Contains(variable), "Supplied variable is not among the updated.");
+
+			Assert.IsNotNull(results.ModifiedFiles, "No props file was updated.");
+			Assert.AreEqual(1, results.ModifiedFiles.Count, "No props file was updated.");
+			Assert.IsTrue(results.ModifiedFiles[0].Succeeded);
+			Assert.IsNull(results.ModifiedFiles[0].Exception);
+			Assert.AreEqual("dotNetCoreVersions.props", Path.GetFileName(results.ModifiedFiles[0].Path));
+		}
+
+		/// <summary>
+		/// Uses a variable outside of the props file's scope and checks to see if props file gets updated.
+		/// Since props file isn't available for that variable, update shouldn't occur.
+		/// </summary>
+		[TestMethod]
+		public void TestPropsFileScope()
+		{
+			// swr is in the root folder while props file will be in a child folder.
+			string msiPath = Path.Combine(Environment.CurrentDirectory, "msi.swr");
+			PropsFileVariableReference variable = new PropsFileVariableReference("WindowsDesktopSharedFramework31Version", "3.3.3", msiPath);
+
+			PropsFileUpdater propsUpdater = new PropsFileUpdater();
+			PropsUpdateResults? results = propsUpdater.UpdatePropsFiles(Enumerable.Repeat(variable, 1), Environment.CurrentDirectory);
+
+			Assert.IsNotNull(results);
+			Assert.IsTrue(results.Outcome);
+
+			Assert.IsNotNull(results.UnrecognizedVariables);
+			Assert.AreEqual(1, results.UnrecognizedVariables.Count);
+			Assert.AreEqual(variable.Name, results.UnrecognizedVariables[0].Name);
+
+			Assert.AreEqual(0, results.UpdatedVariables.Count);
+			Assert.AreEqual(0, results.ModifiedFiles.Count);
+		}
+
+		/// <summary>
+		/// Attempts to deduce the value of a variable in an swr using a publicly available nuget package.
+		/// </summary>
+		[TestMethod]
+		public void TestVariableValueDeduce()
+		{
+			// Generate test default.config
+			string testConfig = @"<?xml version=""1.0"" encoding=""us-ascii""?>
+<corext>
+	<packages>
+		<package id=""runtime.win-x64.Microsoft.NETCore.DotNetAppHost"" version=""unimportant"" link=""path\to\extract"" />
+	</packages>
+</corext>";
+			string defaultConfigPath = Path.GetTempFileName();
+			File.WriteAllText(defaultConfigPath, testConfig);
+
+			// Load default.config
+			DefaultConfigUpdater defaultConfigUpdater = new DefaultConfigUpdater();
+			bool configLoadResult = defaultConfigUpdater.TryLoad(defaultConfigPath, out string error);
+
+			Assert.IsTrue(configLoadResult, "Loading default.config failed.");
+
+			// Load msi.swr
+			string swrPath = Path.Combine(Environment.CurrentDirectory, "Assets", "msi.swr");
+			SwrFileReader swrFileReader = new SwrFileReader(4);
+
+			SwrFile[] loadedSwrFiles = swrFileReader.LoadSwrFiles(Environment.CurrentDirectory);
+			SwrFile swrFile = loadedSwrFiles.First(s => s.Path == swrPath);
+
+			PropsVariableDeducer variableDeducer = new PropsVariableDeducer("https://api.nuget.org/v3/index.json", null);
+			List<PropsFileVariableReference>? results = variableDeducer.DeduceVariableValues(defaultConfigUpdater,
+				new[] { new PackageUpdateResult("runtime.win-x64.Microsoft.NETCore.DotNetAppHost", "unimportant", "3.1.3") },
+				new SwrFile[] { swrFile });
+
+			Assert.IsNotNull(results);
+			Assert.IsTrue(results.Any(r => r.ReferencedFilePath == swrPath), "Cannot find the value of variable in given swr.");
+			Assert.IsTrue(results.Any(r => r.ReferencedFilePath == swrPath && r.Name == "AspNetCoreTargetingPack30Version"), "Cannot find the correct variable.");
+			Assert.IsTrue(results.Any(r => r.ReferencedFilePath == swrPath && r.Name == "AspNetCoreTargetingPack30Version" && r.Value == "apphost"), "Wrong value was found for the variable.");
+		}
+	}
+}


### PR DESCRIPTION
After the changes in this PR, the tool:
 - Searches for swr files under the specified root directory.
 - Looks into these files for payload paths and variable usages like `$(NetCoreToolsetVersion)`
 - Downloads updated nuget packages and extracts contained file lists
 - Compares swr payload paths with nuget contained file paths to deduce values of the variables.
 - Searches for props file under the specified root directory.
 - Updates the props files which contain the previously found variables.

Added tests for the new feature.
Updated README.md to include explanations and examples about new switches.