### PR TITLE
config files will no longer be saved until props files are saved

### DIFF
--- a/src/InsertionsClient/Api/Providers/InsertionApi.cs
+++ b/src/InsertionsClient/Api/Providers/InsertionApi.cs
@@ -71,45 +71,71 @@ namespace Microsoft.Net.Insertions.Api.Providers
                     CreateParallelOptions(source.Token),
                     asset => ParallelCallback(asset, packagesToIgnore, configUpdater, results));
 
-                results.FileSaveResults = configUpdater.Save();
+                /* Delay saving config file changes until props file updates are successfull.
+                 * If we save the results now and props-file step fails, re-running the application won't attempt to update props files again.
+                 * A partial success in the app shouldn't hide the errors in the consecutive runs. */
 
-                if (string.IsNullOrWhiteSpace(propsFilesRootDirectory))
+                // Only update props files if user specified an access token. Null token means user doesn't want to update props files.
+                bool propsUpdatesEnabled = accessToken != null;
+
+                if(propsUpdatesEnabled)
                 {
-                    if (FindPropsFileRootDirectory(defaultConfigFile, out propsFilesRootDirectory))
+                    // Attempt to find a proper directory to search for props files, if we are not already given one.
+                    if (string.IsNullOrWhiteSpace(propsFilesRootDirectory))
                     {
-                        Trace.WriteLine($"The directory to search for .props files: {propsFilesRootDirectory}");
-                    }
-                    else
-                    {
-                        Trace.WriteLine("Failed to find an appropriate folder to search for .props files."
-                            + "Props file updating will be disabled.");
-
-                        results.PropsFileUpdateResults = new PropsUpdateResults()
+                        if (FindPropsFileRootDirectory(defaultConfigFile, out propsFilesRootDirectory))
                         {
-                            Outcome = false,
-                            OutcomeDetails = "Failed to find an appropriate folder to search for .props files."
-                            + "Props file updating will be disabled."
-                        };
+                            Trace.WriteLine($"The directory to search for .props files: {propsFilesRootDirectory}");
+                        }
+                        else
+                        {
+                            Trace.WriteLine("Failed to find an appropriate folder to search for .props files."
+                                + "Props file updating will be disabled.");
+
+                            results.PropsFileUpdateResults = new PropsUpdateResults()
+                            {
+                                Outcome = false,
+                                OutcomeDetails = "Failed to find an appropriate folder to search for .props files."
+                                + "Props file updating will be disabled."
+                            };
+                        }
+                    }
+
+                    // Update props files if we have a valid directory to search
+                    if (!string.IsNullOrWhiteSpace(propsFilesRootDirectory))
+                    {
+                        SwrFileReader swrFileReader = new SwrFileReader(_maxConcurrentWorkers);
+                        SwrFile[] swrFiles = swrFileReader.LoadSwrFiles(propsFilesRootDirectory);
+
+                        PropsVariableDeducer variableDeducer = new PropsVariableDeducer(InsertionConstants.DefaultNugetFeed, accessToken);
+                        bool deduceOperationResult = variableDeducer.DeduceVariableValues(configUpdater, results.UpdatedNuGets,
+                            swrFiles, out List<PropsFileVariableReference> variables, out string outcomeDetails, _maxDownloadSeconds);
+
+                        PropsFileUpdater propsFileUpdater = new PropsFileUpdater();
+                        results.PropsFileUpdateResults = propsFileUpdater.UpdatePropsFiles(variables, propsFilesRootDirectory);
+
+                        if (!deduceOperationResult)
+                        {
+                            results.PropsFileUpdateResults.Outcome = false;
+                            results.PropsFileUpdateResults.OutcomeDetails += outcomeDetails;
+                        }
                     }
                 }
-
-                if (!string.IsNullOrWhiteSpace(propsFilesRootDirectory))
+                else
                 {
-                    SwrFileReader swrFileReader = new SwrFileReader(_maxConcurrentWorkers);
-                    SwrFile[] swrFiles = swrFileReader.LoadSwrFiles(propsFilesRootDirectory);
-
-                    PropsVariableDeducer variableDeducer = new PropsVariableDeducer(InsertionConstants.DefaultNugetFeed, accessToken);
-                    bool deduceOperationResult = variableDeducer.DeduceVariableValues(configUpdater, results.UpdatedNuGets,
-                        swrFiles, out List<PropsFileVariableReference> variables, out string outcomeDetails, _maxDownloadSeconds);
-
-                    PropsFileUpdater propsFileUpdater = new PropsFileUpdater();
-                    results.PropsFileUpdateResults = propsFileUpdater.UpdatePropsFiles(variables, propsFilesRootDirectory);
-
-                    if(!deduceOperationResult)
-                    {
-                        results.PropsFileUpdateResults.Outcome = false;
-                        results.PropsFileUpdateResults.OutcomeDetails += outcomeDetails;
-                    }
+                    Trace.WriteLine(".props file updates are skipped since no access token was specified.");
+                }
+                
+                if(!propsUpdatesEnabled || results.PropsFileUpdateResults!.Outcome == true)
+                {
+                    // Prop files were updated successfuly. It is safe to save config update results.
+                    results.FileSaveResults = configUpdater.Save();
+                }
+                else
+                {
+                    Trace.WriteLine("default.config and .packageconfig file updates were skipped, because " +
+                        "there was an issue updating .props files.");
+                    results.FileSaveResults = new FileSaveResult[0];
                 }
             }
             catch (Exception e)

--- a/src/InsertionsClient/Api/Providers/InsertionApi.cs
+++ b/src/InsertionsClient/Api/Providers/InsertionApi.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Net.Insertions.Api.Providers
                     CreateParallelOptions(source.Token),
                     asset => ParallelCallback(asset, packagesToIgnore, configUpdater, results));
 
-                /* Delay saving config file changes until props file updates are successfull.
+                /* Delay saving config file changes until props file updates are successful.
                  * If we save the results now and props-file step fails, re-running the application won't attempt to update props files again.
                  * A partial success in the app shouldn't hide the errors in the consecutive runs. */
 
@@ -89,14 +89,14 @@ namespace Microsoft.Net.Insertions.Api.Providers
                         }
                         else
                         {
-                            Trace.WriteLine("Failed to find an appropriate folder to search for .props files."
+                            Trace.WriteLine("Failed to find an appropriate folder to search for .props files. "
                                 + "Props file updating will be disabled.");
 
                             results.PropsFileUpdateResults = new PropsUpdateResults()
                             {
                                 Outcome = false,
-                                OutcomeDetails = "Failed to find an appropriate folder to search for .props files."
-                                + "Props file updating will be disabled."
+                                OutcomeDetails = "Failed to find an appropriate folder to search for .props files. "
+                                    + "Props file updating will be disabled."
                             };
                         }
                     }

--- a/src/InsertionsClient/ConsoleApp/Program.cs
+++ b/src/InsertionsClient/ConsoleApp/Program.cs
@@ -187,7 +187,8 @@ namespace Microsoft.Net.Insertions.ConsoleApp
         private static void ShowHelp()
         {
             Console.WriteLine($"{Environment.NewLine}");
-            Console.WriteLine($"{ProgramName.Value} updates versions of NuGet packages in {InsertionConstants.DefaultConfigFile} with the corresponding values from {InsertionConstants.ManifestFile}{Environment.NewLine}");
+            Console.WriteLine($"{ProgramName.Value} updates versions of NuGet packages in {InsertionConstants.DefaultConfigFile} with the corresponding values from {InsertionConstants.ManifestFile}{Environment.NewLine}." +
+                $" If an access token is specified with the switch {SwitchFeedAccessToken}, properties defined in .props files are also updated.");
 
             Console.WriteLine($"Usage:");
             Console.WriteLine($">{ProgramName.Value}.exe {HelpParameters.Value}");
@@ -197,7 +198,7 @@ namespace Microsoft.Net.Insertions.ConsoleApp
             Console.WriteLine($"{SwitchManifest}   full path on disk to manifest.json");
             Console.WriteLine($"{SwitchIgnorePackages}   full path on disk to ignored packages file. Each line should have a package id [optional]");
             Console.WriteLine($"{SwitchPropsFilesRootDir}   directory to search for and update .props files [optional]");
-            Console.WriteLine($"{FeedAccessToken}   token to access nuget feed. Necessary when updating props files [optional]");
+            Console.WriteLine($"{SwitchFeedAccessToken}   token to access nuget feed. Necessary when updating props files [optional]");
             Console.WriteLine($"{SwitchMaxWaitSeconds}   maximum allowed duration in seconds, excluding downloads [optional]");
             Console.WriteLine($"{SwitchMaxDownloadSeconds}   maximum allowed duration in seconds that can be spent downloading nuget packages [optional]");
             Console.WriteLine($"{SwitchMaxConcurrency}   maximum concurrency of default.config version updates [optional]{Environment.NewLine}");


### PR DESCRIPTION
Fixes #23 

Problem: If config files are updated and props file updates fail, local repo gets into a partially updated state. In this state, re-running the tool doesn't attempt to update props files anymore, because all the packages appear to be up-to-date.

To prevent this, config file saves are delayed now until props files are successfully saved.

I also updated help text to make the following obvious: not specifying an access token will result in no props file being updated.