### PR TITLE
Make default ignored packages immutable

### DIFF
--- a/src/InsertionsClient.Console/ConsoleApp/Program.cs
+++ b/src/InsertionsClient.Console/ConsoleApp/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.Net.Insertions.Models;
 using Microsoft.Net.Insertions.Props.Models;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -122,7 +123,7 @@ namespace Microsoft.Net.Insertions.ConsoleApp
             }
             else
             {
-                results = api.UpdateVersions(ManifestFile, DefaultConfigFile, (HashSet<string>?)null, FeedAccessToken, PropsFilesRootDirectory);
+                results = api.UpdateVersions(ManifestFile, DefaultConfigFile, ImmutableHashSet<string>.Empty, FeedAccessToken, PropsFilesRootDirectory);
             }
 
             ShowResults(results);

--- a/src/InsertionsClient.Core/Api/IInsertionApi.cs
+++ b/src/InsertionsClient.Core/Api/IInsertionApi.cs
@@ -2,6 +2,7 @@
 
 using Microsoft.Net.Insertions.Models;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("InsertionsClient.Test")]
@@ -33,6 +34,6 @@ namespace Microsoft.Net.Insertions.Api
         /// <param name="accessToken">Access token used when connecting to nuget feed.</param>
         /// <param name="propsFilesRootDirectory">Directory that will be searched for props files.</param>
         /// <returns><see cref="UpdateResults"/> detailing the operation's outcome.</returns>
-        UpdateResults UpdateVersions(string manifestFile, string defaultConfigFile, HashSet<string>? packagesToIgnore, string? accessToken, string? propsFilesRootDirectory);
+        UpdateResults UpdateVersions(string manifestFile, string defaultConfigFile, ImmutableHashSet<string>? packagesToIgnore, string? accessToken, string? propsFilesRootDirectory);
     }
 }

--- a/src/InsertionsClient.Core/Api/Providers/InsertionApi.cs
+++ b/src/InsertionsClient.Core/Api/Providers/InsertionApi.cs
@@ -10,6 +10,7 @@ using Microsoft.Net.Insertions.Telemetry;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -47,7 +48,7 @@ namespace Microsoft.Net.Insertions.Api.Providers
             return UpdateVersions(manifestFile, defaultConfigFile, LoadPackagesToIgnore(ignoredPackagesFile), accessToken, propsFilesRootDirectory);
         }
 
-        public UpdateResults UpdateVersions(string manifestFile, string defaultConfigFile, HashSet<string>? packagesToIgnore, string? accessToken = null, string? propsFilesRootDirectory = null)
+        public UpdateResults UpdateVersions(string manifestFile, string defaultConfigFile, ImmutableHashSet<string>? packagesToIgnore, string? accessToken = null, string? propsFilesRootDirectory = null)
         {
             List<Asset> assets = null!;
             DefaultConfigUpdater configUpdater;
@@ -241,11 +242,11 @@ namespace Microsoft.Net.Insertions.Api.Providers
             return configUpdater.TryLoad(defaultConfigPath, out details);
         }
 
-        private HashSet<string> LoadPackagesToIgnore(string ignoredPackagesFile)
+        private ImmutableHashSet<string> LoadPackagesToIgnore(string ignoredPackagesFile)
         {
             if (!File.Exists(ignoredPackagesFile))
             {
-                return new HashSet<string>();
+                return ImmutableHashSet<string>.Empty;
             }
 
             HashSet<string> ignoredPackages = new HashSet<string>();
@@ -256,10 +257,10 @@ namespace Microsoft.Net.Insertions.Api.Providers
                 ignoredPackages.Add(line);
             }
 
-            return ignoredPackages;
+            return ignoredPackages.ToImmutableHashSet();
         }
 
-        private void ParallelCallback(Asset asset, HashSet<string>? packagesToIgnore, DefaultConfigUpdater configUpdater, UpdateResults results)
+        private void ParallelCallback(Asset asset, ImmutableHashSet<string>? packagesToIgnore, DefaultConfigUpdater configUpdater, UpdateResults results)
         {
             Stopwatch stopWatch = Stopwatch.StartNew();
 

--- a/src/InsertionsClient.Core/Common/Constants/InsertionConstants.cs
+++ b/src/InsertionsClient.Core/Common/Constants/InsertionConstants.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Microsoft.Net.Insertions.Common.Constants
 {
@@ -10,14 +11,14 @@ namespace Microsoft.Net.Insertions.Common.Constants
 
         public const string ManifestFile = "manifest.json";
 
-        public static readonly HashSet<string> DefaultDevUxTeamPackages = new HashSet<string>
+        public static readonly ImmutableHashSet<string> DefaultDevUxTeamPackages = new string[]
         {
             "Microsoft.VisualStudio.LiveShare",
             "System.Reflection.Metadata",
             "VS.ExternalAPIs.MSBuild",
             "VS.Tools.Net.Core.SDK.Resolver",
             "VS.Tools.Net.Core.SDK.x86"
-        };
+        }.ToImmutableHashSet();
 
         internal const string DefaultNugetFeed = "https://pkgs.dev.azure.com/devdiv/_packaging/VS-CoreXtFeeds/nuget/v3/index.json";
     }

--- a/src/InsertionsClient.Core/Models/UpdateResults.cs
+++ b/src/InsertionsClient.Core/Models/UpdateResults.cs
@@ -3,6 +3,7 @@
 using Microsoft.Net.Insertions.Props.Models;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 
 namespace Microsoft.Net.Insertions.Models
@@ -28,7 +29,7 @@ namespace Microsoft.Net.Insertions.Models
         /// <summary>
         /// Ids of ignored nuget packages.
         /// </summary>
-        public HashSet<string>? IgnoredNuGets { get; set; }
+        public ImmutableHashSet<string>? IgnoredNuGets { get; set; }
 
         /// <summary>
         /// Duration in ms of <see cref="IInsertionApi.UpdateVersions(string, string, string)"/> attempt.


### PR DESCRIPTION
Improvement over PR #36 (needs to be merged after)

Changes the type of `InsertionConstants.DefaultDevUxTeamPackages` to `ImmutableHashSet` to prevent external modifications.